### PR TITLE
Fix AreaInfo namespace reference

### DIFF
--- a/CentrED/UI/Windows/ProceduralGeneratorWindow.cs
+++ b/CentrED/UI/Windows/ProceduralGeneratorWindow.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using CentrED.Client;
 using CentrED.Client.Map;
 using CentrED.IO.Models;
+using CentrED.Network;
 using ImGuiNET;
 using static CentrED.Application;
 


### PR DESCRIPTION
## Summary
- include `CentrED.Network` namespace in `ProceduralGeneratorWindow`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684708e938d8832f8804f1c7bdfaf58f