### PR TITLE
Prevent dockspace crash with small viewport

### DIFF
--- a/CentrED/UI/UIManager.cs
+++ b/CentrED/UI/UIManager.cs
@@ -451,7 +451,10 @@ public class UIManager
         //Copy of DockSpaceOverViewport with reduced host window size
         var vp = ImGui.GetMainViewport();
         ImGui.SetNextWindowPos(vp.WorkPos);
-        ImGui.SetNextWindowSize(vp.WorkSize with {Y = vp.WorkSize.Y - statusBarHeight});
+        float dockHeight = vp.WorkSize.Y - statusBarHeight;
+        if (dockHeight < 0f)
+            dockHeight = 0f;
+        ImGui.SetNextWindowSize(new Vector2(vp.WorkSize.X, dockHeight));
         ImGui.SetNextWindowViewport(vp.ID);
         var hostFlags = ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize |
                         ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoDocking | ImGuiWindowFlags.NoBringToFrontOnFocus |
@@ -464,12 +467,15 @@ public class UIManager
         ImGui.Begin($"WindowOverViewport_{vp.ID}", hostFlags);
         ImGui.PopStyleVar(3);
         var dockId = ImGui.GetID("DockSpace");
-        ImGui.DockSpace
-        (
-            dockId,
-            new Vector2(0, 0),
-            ImGuiDockNodeFlags.PassthruCentralNode | ImGuiDockNodeFlags.NoDockingOverCentralNode
-        );
+        if (ImGui.GetIO().ConfigFlags.HasFlag(ImGuiConfigFlags.DockingEnable))
+        {
+            ImGui.DockSpace
+            (
+                dockId,
+                new Vector2(0, 0),
+                ImGuiDockNodeFlags.PassthruCentralNode | ImGuiDockNodeFlags.NoDockingOverCentralNode
+            );
+        }
 
         ImGui.End();
     }


### PR DESCRIPTION
## Summary
- ensure dock space height never becomes negative
- only create docking space if docking is enabled

## Testing
- `dotnet build CentrEDSharp.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470a0dcd04832f8702e51ed59b5847