### PR TITLE
Fix ProceduralGeneratorWindow group selection

### DIFF
--- a/CentrED/UI/Windows/ProceduralGeneratorWindow.cs
+++ b/CentrED/UI/Windows/ProceduralGeneratorWindow.cs
@@ -198,6 +198,7 @@ public class ProceduralGeneratorWindow : Window
         {
             foreach (var kv in groups.ToArray())
             {
+                ImGui.PushID($"{(land ? "l" : "s")}_{kv.Key}");
                 bool isSel = selected == kv.Key;
                 if (ImGui.Selectable(kv.Key, isSel))
                     selected = kv.Key;
@@ -211,6 +212,7 @@ public class ProceduralGeneratorWindow : Window
                     }
                     ImGui.EndPopup();
                 }
+                ImGui.PopID();
             }
             ImGui.EndChild();
         }


### PR DESCRIPTION
## Summary
- ensure unique ImGui IDs for ProceduralGeneratorWindow group entries

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470c39fd94832f9f58c48814357fac