### PR TITLE
Fix groups serialization

### DIFF
--- a/CentrED/UI/Windows/ProceduralGeneratorWindow.cs
+++ b/CentrED/UI/Windows/ProceduralGeneratorWindow.cs
@@ -356,7 +356,11 @@ public class ProceduralGeneratorWindow : Window
             TileGroups = tileGroups,
             StaticGroups = staticGroups
         };
-        var options = new JsonSerializerOptions { WriteIndented = true };
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            IncludeFields = true
+        };
         File.WriteAllText(GroupsFile, JsonSerializer.Serialize(data, options));
     }
 
@@ -364,7 +368,10 @@ public class ProceduralGeneratorWindow : Window
     {
         if (!File.Exists(GroupsFile))
             return;
-        var data = JsonSerializer.Deserialize<GroupsData>(File.ReadAllText(GroupsFile));
+        var data = JsonSerializer.Deserialize<GroupsData>(File.ReadAllText(GroupsFile), new JsonSerializerOptions
+        {
+            IncludeFields = true
+        });
         if (data == null)
             return;
         tileGroups.Clear();


### PR DESCRIPTION
## Summary
- ensure group data fields are serialized in ProceduralGeneratorWindow

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684768338268832fa6cd2a02f9093923