### PR TITLE
Fix GptTile definition

### DIFF
--- a/CentrED/UI/Windows/ProceduralGeneratorWindow.cs
+++ b/CentrED/UI/Windows/ProceduralGeneratorWindow.cs
@@ -49,6 +49,8 @@ public class ProceduralGeneratorWindow : Window
 
     private static readonly string[] RegionNames = Enum.GetNames<Region>();
 
+    private record struct GptTile(int x, int y, ushort tileId, int height);
+
     protected override void InternalDraw()
     {
         if (!CEDClient.Initialized)
@@ -293,7 +295,6 @@ public class ProceduralGeneratorWindow : Window
             }
         }
 
-        record GptTile(int x, int y, ushort tileId, int height);
     }
 
     private (ushort landId, sbyte altitudeOffset, sbyte altitudeRange, ushort staticId, float staticChance) GetSettings(Region region)


### PR DESCRIPTION
## Summary
- define a nested `GptTile` record struct instead of a C# 12 local type

## Testing
- `dotnet build --no-restore` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847772146b0832fb9b204bf25efe104