### PR TITLE
Reduce debug spam when drawing map

### DIFF
--- a/Client/Map/ClientLandscapePacketHandlers.cs
+++ b/Client/Map/ClientLandscapePacketHandlers.cs
@@ -37,7 +37,9 @@ public partial class ClientLandscape
 
     private void OnDrawMapPacket(BinaryReader reader, NetState<CentrEDClient> ns)
     {
-        ns.LogDebug("Client OnDrawMapPacket");
+        // Spammy debug logging of every map draw causes performance issues
+        // when large areas are generated. Disable per-tile logging for smoother
+        // bulk operations.
         var x = reader.ReadUInt16();
         var y = reader.ReadUInt16();
 

--- a/Server/Map/ServerLandscapePacketHandlers.cs
+++ b/Server/Map/ServerLandscapePacketHandlers.cs
@@ -8,7 +8,10 @@ public partial class ServerLandscape
     private static readonly Random Random = new();
     private void OnDrawMapPacket(BinaryReader reader, NetState<CEDServer> ns)
     {
-        ns.LogDebug("Server OnDrawMapPacket");
+        // Removing debug logging for every tile draw drastically reduces
+        // console output during large scale operations such as the
+        // procedural generator. Excessive logging was causing noticeable
+        // stalls when generating big regions (e.g. 1000x1000 tiles).
         var x = reader.ReadUInt16();
         var y = reader.ReadUInt16();
         if (!PacketHandlers.ValidateAccess(ns, AccessLevel.Normal, x, y))


### PR DESCRIPTION
## Summary
- remove per-tile debug logs from map drawing packet handlers

## Testing
- `dotnet build CentrEDSharp.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478ee24e08832fb708c98c60bbcee6