### PR TITLE
Fix crash from invalid land tile IDs

### DIFF
--- a/CentrED/Map/LandObject.cs
+++ b/CentrED/Map/LandObject.cs
@@ -43,6 +43,9 @@ public class LandObject : TileObject
 
     private bool AlwaysFlat(ushort id)
     {
+        if (id >= TileDataLoader.Instance.LandData.Length)
+            return false;
+
         ref var tileData = ref TileDataLoader.Instance.LandData[id];
         // Water tiles are always flat
         return tileData.TexID == 0 || tileData.IsWet;


### PR DESCRIPTION
## Summary
- avoid indexing beyond `TileDataLoader` bounds when land tile ids are invalid

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684794fb8568832f9dbb6179f9958308