### PR TITLE
Fix file reader offsets

### DIFF
--- a/Server/Map/RadarMap.cs
+++ b/Server/Map/RadarMap.cs
@@ -29,10 +29,12 @@ public class RadarMap
             {
                 var block = landscape.GetBlockNumber(x, y);
                 mapReader.BaseStream.Seek(landscape.GetMapOffset(x, y) + 4, SeekOrigin.Begin);
+                mapReader.DiscardBufferedData();
                 var landTile = new LandTile(mapReader);
                 _radarMap[block] = _radarColors[landTile.Id];
 
                 staidxReader.BaseStream.Seek(landscape.GetStaidxOffset(x, y), SeekOrigin.Begin);
+                staidxReader.DiscardBufferedData();
                 var index = new GenericIndex(staidxReader);
                 var staticsBlock = new StaticBlock(landscape, staticsReader, index, x, y);
 

--- a/Server/Map/ServerLandscape.cs
+++ b/Server/Map/ServerLandscape.cs
@@ -225,9 +225,13 @@ public sealed partial class ServerLandscape : BaseLandscape, IDisposable, ILoggi
     {
         AssertBlockCoords(x, y);
         _map.Position = GetMapOffset(x, y);
+        _mapReader.BaseStream.Seek(_map.Position, SeekOrigin.Begin);
+        _mapReader.DiscardBufferedData();
         var map = new LandBlock(this, x, y, _mapReader);
 
         _staidx.Position = GetStaidxOffset(x, y);
+        _staidxReader.BaseStream.Seek(_staidx.Position, SeekOrigin.Begin);
+        _staidxReader.DiscardBufferedData();
         var index = new GenericIndex(_staidxReader);
         var statics = new StaticBlock(this, _staticsReader, index, x, y);
 
@@ -449,6 +453,7 @@ public sealed partial class ServerLandscape : BaseLandscape, IDisposable, ILoggi
                 for (ushort y = 0; y < Height; y++)
                 {
                     _staidxReader.BaseStream.Seek(GetStaidxOffset(x, y), SeekOrigin.Begin);
+                    _staidxReader.DiscardBufferedData();
                     var index = new GenericIndex(_staidxReader);
                     if (index.Lookup >= _statics.Length && index.Length > 0)
                     {

--- a/Shared/StaticBlock.cs
+++ b/Shared/StaticBlock.cs
@@ -20,7 +20,8 @@ public class StaticBlock
 
         if (reader != null && index?.Lookup >= 0 && index.Length > 0)
         {
-            reader.BaseStream.Position = index.Lookup;
+            reader.BaseStream.Seek(index.Lookup, SeekOrigin.Begin);
+            reader.DiscardBufferedData();
             for (var i = 0; i < index.Length / 7; i++)
             {
                 AddTileInternal(new StaticTile(reader, this, x, y));


### PR DESCRIPTION
## Summary
- ensure binary reader buffers are discarded when seeking new offsets
- adjust static block load to reset stream position
- reset radar map readers for each iteration

## Testing
- `dotnet format --no-restore` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68479622c064832fac05790d2665cac1