### PR TITLE
Fix BinaryReader reset for cross-platform compatibility

### DIFF
--- a/Shared/StaticBlock.cs
+++ b/Shared/StaticBlock.cs
@@ -21,7 +21,7 @@ public class StaticBlock
         if (reader != null && index?.Lookup >= 0 && index.Length > 0)
         {
             reader.BaseStream.Seek(index.Lookup, SeekOrigin.Begin);
-            reader.DiscardBufferedData();
+            reader = new BinaryReader(reader.BaseStream, reader.CurrentEncoding, leaveOpen: true);
             for (var i = 0; i < index.Length / 7; i++)
             {
                 AddTileInternal(new StaticTile(reader, this, x, y));


### PR DESCRIPTION
## Summary
- avoid using `DiscardBufferedData` in `StaticBlock`

## Testing
- `dotnet build CentrEDSharp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847974c5f50832fa3d6842bb7f470f3