### PR TITLE
Fix fullscreen start and crash on resize

### DIFF
--- a/CentrED/CentrEDGame.cs
+++ b/CentrED/CentrEDGame.cs
@@ -22,7 +22,9 @@ public class CentrEDGame : Game
         _gdm = new GraphicsDeviceManager(this)
         {
             IsFullScreen = false,
-            PreferredDepthStencilFormat = DepthFormat.Depth24
+            PreferredDepthStencilFormat = DepthFormat.Depth24,
+            PreferredBackBufferWidth = 1280,
+            PreferredBackBufferHeight = 720
         };
 
         _gdm.PreparingDeviceSettings += (sender, e) =>
@@ -58,7 +60,6 @@ public class CentrEDGame : Game
     protected override void BeginRun()
     {
         base.BeginRun();
-        SDL_MaximizeWindow(Window.Handle);
     }
 
     protected override void UnloadContent()

--- a/CentrED/Map/MapManager.cs
+++ b/CentrED/Map/MapManager.cs
@@ -1390,6 +1390,16 @@ public class MapManager
     public void OnWindowsResized(GameWindow window)
     {
         var windowSize = window.ClientBounds;
+        if (windowSize.Width <= 0 || windowSize.Height <= 0)
+        {
+            return;
+        }
+        if (_selectionBuffer != null &&
+            _selectionBuffer.Width == windowSize.Width &&
+            _selectionBuffer.Height == windowSize.Height)
+        {
+            return;
+        }
         Camera.ScreenSize = windowSize;
         Camera.Update();
 


### PR DESCRIPTION
## Summary
- set window buffer size and remove automatic maximize so the client starts windowed
- skip resizing render targets when the new size is invalid or unchanged

## Testing
- `dotnet build CentrEDSharp.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68479c27476c832f9301b91fbba450b8