### PR TITLE
Fix blocks list initialization

### DIFF
--- a/Server/PacketHandlers.cs
+++ b/Server/PacketHandlers.cs
@@ -56,7 +56,7 @@ public static class PacketHandlers
         ns.LogDebug("Server OnRequestBlocksPacket");
         if (!ValidateAccess(ns, AccessLevel.View))
             return;
-        var blocksCount = (buffer.BaseStream.Length - buffer.BaseStream.Position) / 4; // x and y, both 2 bytes
+        var blocksCount = (int)((buffer.BaseStream.Length - buffer.BaseStream.Position) / 4); // x and y, both 2 bytes
         var blocks = new List<BlockCoords>(blocksCount);
         for (var i = 0; i < blocksCount; i++)
         {


### PR DESCRIPTION
## Summary
- fix initialization of `blocks` list in packet handler

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a0a8ee0c832f8bbe018a82dbe42d