### PR TITLE
Fix enumeration crash in MapManager

### DIFF
--- a/CentrED/Map/MapManager.cs
+++ b/CentrED/Map/MapManager.cs
@@ -794,7 +794,9 @@ public class MapManager
                 animatedStaticTile.UpdateId();
             }
         }
-        foreach (var landObject in _ToRecalculate)
+        var toRecalculate = _ToRecalculate.ToArray();
+        _ToRecalculate.Clear();
+        foreach (var landObject in toRecalculate)
         {
             if (GhostLandTiles.TryGetValue(landObject, out var ghostLandObject))
             {
@@ -802,7 +804,6 @@ public class MapManager
             }
             landObject.Update();
         }
-        _ToRecalculate.Clear();
         Metrics.Stop("UpdateMap");
     }
 


### PR DESCRIPTION
## Summary
- safeguard `_ToRecalculate` enumeration from collection-modification errors

## Testing
- `dotnet build CentrEDSharp.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a508fe38832fb05b164d08544603