### PR TITLE
Fix concurrency in tile recalculation and guard stream dequeue

### DIFF
--- a/CentrED/Tools/AltitudeGradientTool.cs
+++ b/CentrED/Tools/AltitudeGradientTool.cs
@@ -452,7 +452,7 @@ public class AltitudeGradientTool : BaseTool
                     {
                         LandObject? neighborTile = MapManager.LandTiles[nx, ny];
                         if (neighborTile != null)
-                            MapManager._ToRecalculate.Add(neighborTile);
+                            MapManager.AddToRecalculate(neighborTile);
                     }
                 }
             }
@@ -540,7 +540,7 @@ public class AltitudeGradientTool : BaseTool
                     {
                         LandObject? neighborTile = MapManager.LandTiles[nx, ny];
                         if (neighborTile != null)
-                            MapManager._ToRecalculate.Add(neighborTile);
+                            MapManager.AddToRecalculate(neighborTile);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- prevent concurrent writes to `_ToRecalculate` and use `AddToRecalculate` helper
- guard network stream dequeue logic against invalid offsets
- update tools to use new helper method

## Testing
- `dotnet build CentrEDSharp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a8d00140832f92dbe7cfb54644d8