### PR TITLE
Increase procedural generator area limit

### DIFF
--- a/CentrED/UI/Windows/ProceduralGeneratorWindow.cs
+++ b/CentrED/UI/Windows/ProceduralGeneratorWindow.cs
@@ -56,7 +56,8 @@ public class ProceduralGeneratorWindow : Window
 
     private string apiKey = string.Empty;
     private const int BlockSize = 256;
-    private const int MaxTiles = 1024 * 1024; // safety limit for generation
+    // Increased limit to allow up to 16,777,216 tiles
+    private const int MaxTiles = 16 * 1024 * 1024; // safety limit for generation
 
     private string gptResponse = string.Empty;
 


### PR DESCRIPTION
## Summary
- adjust safety limit to allow generating much larger areas

## Testing
- `dotnet build --no-restore` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847ad1823d4832fb5a740fd3b3a22e3