### PR TITLE
Fix compressed packet trailing zeros

### DIFF
--- a/Shared/Network/Packets.cs
+++ b/Shared/Network/Packets.cs
@@ -14,6 +14,7 @@ public class CompressedPacket : Packet
         zLibStream.Flush();
         zLibStream.Close();
         Writer.Write((uint)packet.Stream.Length);
-        Writer.Write(compressedData.GetBuffer());
+        var compressedBuffer = compressedData.ToArray();
+        Writer.Write(compressedBuffer);
     }
 }


### PR DESCRIPTION
## Summary
- ensure CompressedPacket writes only the actual compressed data

## Testing
- `dotnet build --no-restore` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847b15c3b20832f9c1790a14c9e6291