### PR TITLE
Implement map packet handshake

### DIFF
--- a/Client/AckHandling.cs
+++ b/Client/AckHandling.cs
@@ -1,0 +1,13 @@
+using System.IO;
+using CentrED.Network;
+
+namespace CentrED.Client;
+
+public static class AckHandling
+{
+    public static void OnMapAckPacket(BinaryReader reader, NetState<CentrEDClient> ns)
+    {
+        ns.LogDebug("Client OnMapAckPacket");
+        ns.Parent.AwaitingAck = false;
+    }
+}

--- a/Client/Map/ClientLandscape.cs
+++ b/Client/Map/ClientLandscape.cs
@@ -35,23 +35,23 @@ public partial class ClientLandscape : BaseLandscape
         LandTileReplaced += (tile, newId, newZ) =>
         {
             _client.PushUndoPacket(new DrawMapPacket(tile));
-            _client.Send(new DrawMapPacket(tile, newId, newZ));
+            _client.SendAndWait(new DrawMapPacket(tile, newId, newZ));
         };
         LandTileElevated += (tile, newZ) =>
         {
             _client.PushUndoPacket(new DrawMapPacket(tile));
-            _client.Send(new DrawMapPacket(tile, newZ));
+            _client.SendAndWait(new DrawMapPacket(tile, newZ));
         };
 
         StaticTileAdded += tile =>
         {
             _client.PushUndoPacket(new DeleteStaticPacket(tile));
-            _client.Send(new InsertStaticPacket(tile));
+            _client.SendAndWait(new InsertStaticPacket(tile));
         };
         StaticTileRemoved += tile =>
         {
             _client.PushUndoPacket(new InsertStaticPacket(tile));
-            _client.Send(new DeleteStaticPacket(tile));
+            _client.SendAndWait(new DeleteStaticPacket(tile));
         };
         StaticTileReplaced += (tile, newId) =>
         {
@@ -61,23 +61,23 @@ public partial class ClientLandscape : BaseLandscape
             if(shouldEndGroup)
                 _client.EndUndoGroup();
             
-            _client.Send(new DeleteStaticPacket(tile));
-            _client.Send(new InsertStaticPacket(tile.X, tile.Y, tile.Z, newId, tile.Hue));
+            _client.SendAndWait(new DeleteStaticPacket(tile));
+            _client.SendAndWait(new InsertStaticPacket(tile.X, tile.Y, tile.Z, newId, tile.Hue));
         };
         StaticTileMoved += (tile, newX, newY) =>
         {
             _client.PushUndoPacket(new MoveStaticPacket(newX, newY, tile.Z, tile.Id, tile.Hue, tile.X, tile.Y));
-            _client.Send(new MoveStaticPacket(tile, newX, newY));
+            _client.SendAndWait(new MoveStaticPacket(tile, newX, newY));
         };
         StaticTileElevated += (tile, newZ) =>
         {
             _client.PushUndoPacket(new ElevateStaticPacket(tile.X, tile.Y, newZ, tile.Id, tile.Hue, tile.Z));
-            _client.Send(new ElevateStaticPacket(tile, newZ));
+            _client.SendAndWait(new ElevateStaticPacket(tile, newZ));
         };
         StaticTileHued += (tile, newHue) =>
         {
             _client.PushUndoPacket(new HueStaticPacket(tile.X, tile.Y, tile.Z, tile.Id,newHue, tile.Hue));
-            _client.Send(new HueStaticPacket(tile, newHue));
+            _client.SendAndWait(new HueStaticPacket(tile, newHue));
         };
     }
 

--- a/Client/PacketHandlers.cs
+++ b/Client/PacketHandlers.cs
@@ -15,6 +15,7 @@ public static class PacketHandlers
         RegisterPacketHandler(0x03, 0, AdminHandling.OnAdminHandlerPacket);
         RegisterPacketHandler(0x0C, 0, ClientHandling.OnClientHandlerPacket);
         RegisterPacketHandler(0x0D, 0, RadarMap.OnRadarHandlerPacket);
+        RegisterPacketHandler(0x10, 1, AckHandling.OnMapAckPacket);
     }
 
     public static void RegisterPacketHandler

--- a/Server/Map/ServerLandscapePacketHandlers.cs
+++ b/Server/Map/ServerLandscapePacketHandlers.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using CentrED.Network;
+using CentrED.Server;
 
 namespace CentrED.Server.Map;
 
@@ -33,6 +34,7 @@ public partial class ServerLandscape
         }
 
         UpdateRadar(ns, x, y);
+        ns.Send(new MapAckPacket());
     }
 
     private void OnInsertStaticPacket(BinaryReader reader, NetState<CEDServer> ns)
@@ -58,6 +60,7 @@ public partial class ServerLandscape
         }
 
         UpdateRadar(ns, staticInfo.X, staticInfo.Y);
+        ns.Send(new MapAckPacket());
     }
 
     private void OnDeleteStaticPacket(BinaryReader reader, NetState<CEDServer> ns)
@@ -83,6 +86,7 @@ public partial class ServerLandscape
         }
 
         UpdateRadar(ns, x, y);
+        ns.Send(new MapAckPacket());
     }
 
     private void OnElevateStaticPacket(BinaryReader reader, NetState<CEDServer> ns)
@@ -110,6 +114,7 @@ public partial class ServerLandscape
         }
 
         UpdateRadar(ns, x, y);
+        ns.Send(new MapAckPacket());
     }
 
     private void OnMoveStaticPacket(BinaryReader reader, NetState<CEDServer> ns)
@@ -175,6 +180,7 @@ public partial class ServerLandscape
 
         UpdateRadar(ns, staticInfo.X, staticInfo.Y);
         UpdateRadar(ns, newX, newY);
+        ns.Send(new MapAckPacket());
     }
 
     private void OnHueStaticPacket(BinaryReader reader, NetState<CEDServer> ns)
@@ -199,6 +205,8 @@ public partial class ServerLandscape
         {
             netState.Send(packet);
         }
+
+        ns.Send(new MapAckPacket());
     }
 
     [SuppressMessage("ReSharper", "PossibleMultipleEnumeration")]

--- a/Server/Packets.cs
+++ b/Server/Packets.cs
@@ -148,6 +148,13 @@ public class QuitAckPacket : Packet
     }
 }
 
+public class MapAckPacket : Packet
+{
+    public MapAckPacket() : base(0x10, 1)
+    {
+    }
+}
+
 public class ServerStatePacket : Packet
 {
     public ServerStatePacket(ServerState state, string message = "") : base(0x02, 0)


### PR DESCRIPTION
## Summary
- add ack tracking in client and a new `SendAndWait` method
- register an ack packet handler and implement `AckHandling`
- send ack packets from server after map edits
- use `SendAndWait` for all map edit events

## Testing
- `dotnet build CentrEDSharp.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847b2a0a7a0832f8e11c28b3444ef1f