### PR TITLE
Add file selection for HeightMapGenerator groups

### DIFF
--- a/CentrED/TinyFileDialogs.cs
+++ b/CentrED/TinyFileDialogs.cs
@@ -102,4 +102,10 @@ public class TinyFileDialogs
         result = stringFromAnsi(tinyfd_openFileDialog(title, defaultPathAndFile, filterPatterns.Length, filterPatterns, singleFilterDescription, allowMultipleSelects ? 1 : 0));
         return !string.IsNullOrEmpty(result);
     }
+
+    public static bool TrySaveFile(string title, string defaultPathAndFile, string[] filterPatterns, string singleFilterDescription, out string result)
+    {
+        result = stringFromAnsi(tinyfd_saveFileDialog(title, defaultPathAndFile, filterPatterns.Length, filterPatterns, singleFilterDescription));
+        return !string.IsNullOrEmpty(result);
+    }
 }


### PR DESCRIPTION
## Summary
- allow saving/loading tile group files from chosen paths
- expose a tiny file dialog save file wrapper

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847d1df5d88832f8a3427bb4364cf1a