### PR TITLE
Fix BulkMode flush

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator.cs
@@ -230,6 +230,8 @@ public class HeightMapGenerator : Window
             {
                 CEDClient.BulkMode = false;
                 CEDClient.Flush();
+                // Ensure pending packets are sent immediately after bulk mode
+                CEDClient.Update();
             }
             generationProgress = 1f;
         });


### PR DESCRIPTION
## Summary
- ensure pending packets flush after disabling BulkMode

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e5adaa54832f969ae95a103d0a05