### PR TITLE
Fix undo memory usage during heightmap generation

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator.cs
@@ -195,6 +195,7 @@ public class HeightMapGenerator : Window
             if (total > MaxTiles)
                 return;
             CEDClient.BulkMode = true;
+            CEDClient.BeginUndoGroup();
             try
             {
                 for (int bx = 0; bx < MapSize; bx += BlockSize)
@@ -228,6 +229,7 @@ public class HeightMapGenerator : Window
             }
             finally
             {
+                CEDClient.EndUndoGroup();
                 CEDClient.BulkMode = false;
                 CEDClient.Flush();
                 // Ensure pending packets are sent immediately after bulk mode


### PR DESCRIPTION
## Summary
- wrap heightmap generation in a single undo group

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e8324830832f8858dff845dc39de