### PR TITLE
Disable undo stack for heightmap generation

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator.cs
@@ -112,6 +112,7 @@ public class HeightMapGenerator : Window
             Generate();
         }
         ImGui.EndDisabled();
+        ImGui.TextColored(UIManager.Red, "This operation cannot be undone!");
         if (generationTask != null)
         {
             if (generationTask.IsCompleted)
@@ -195,7 +196,6 @@ public class HeightMapGenerator : Window
             if (total > MaxTiles)
                 return;
             CEDClient.BulkMode = true;
-            CEDClient.BeginUndoGroup();
             try
             {
                 for (int bx = 0; bx < MapSize; bx += BlockSize)
@@ -229,7 +229,6 @@ public class HeightMapGenerator : Window
             }
             finally
             {
-                CEDClient.EndUndoGroup();
                 CEDClient.BulkMode = false;
                 CEDClient.Flush();
                 // Ensure pending packets are sent immediately after bulk mode

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ Este projeto é um fork do [CentrED original](https://git.aksdb.de/aksdb/CentrED
 
 - **Compatibilidade multiplataforma**: Suporte para Linux e macOS foi adicionado, permitindo compilar e executar o editor em diferentes sistemas operacionais.
 - **Integração com ChatGPT**: O gerador procedural de terreno possui integração opcional com a API do ChatGPT para criação de tiles e grupos a partir de prompts. A chave de acesso pode ser salva e carregada diretamente na interface.
-- **Gerador baseado em HeightMap**: Além do gerador procedural padrão, existe uma janela de geração por mapa de altura com seleção de quadrantes e salvamento de grupos em JSON.
+- **Gerador baseado em HeightMap**: Além do gerador procedural padrão, existe uma janela de geração por mapa de altura com seleção de quadrantes e salvamento de grupos em JSON. **A geração não possui suporte a undo.**
 - **Melhorias de desempenho e estabilidade**: Várias correções de concorrência, otimizações no carregamento e salvamento de blocos e tratamento de pacotes de rede desconhecidos.
 - **Operações em larga escala**: Implementação de comandos e tratamento de Large Scale Operations (LSO) para modificar grandes áreas do mapa de forma segura.
 - **BulkMode**: Novo modo de envio em lote no cliente para otimizar grandes gerações de mapa, utilizado pelo gerador de HeightMap.


### PR DESCRIPTION
## Summary
- remove BeginUndoGroup/EndUndoGroup from heightmap generator
- display warning that heightmap generation can't be undone
- mention the limitation in README

## Testing
- `dotnet build --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ec7a8870832fa3f7bd6d768da07a