### PR TITLE
Refine Perlin height ranges

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator.cs
@@ -29,6 +29,19 @@ public class HeightMapGenerator : Window
     private const int MaxTiles = 16 * 1024 * 1024;
     private const string GroupsFile = "heightmap_groups.json";
 
+    private static readonly (sbyte Min, sbyte Max)[] HeightRanges =
+    {
+        (-127, -126), // water
+        (-125, -100), // sand
+        (-99, -74),   // grass
+        (-73, -48),   // jungle
+        (-47, -23),   // rock
+        (-22, 3)      // snow
+    };
+    private const int NUM_CHANNELS = 6;
+    private const float NOISE_SCALE = 0.05f;
+    private const float NOISE_ROUGHNESS = 0.5f;
+
     private string groupsPath = GroupsFile;
 
     private string heightMapPath = string.Empty;
@@ -37,6 +50,8 @@ public class HeightMapGenerator : Window
     private int heightMapWidth;
     private int heightMapHeight;
     private int selectedQuadrant = 0;
+
+    private readonly Perlin noise = new(Environment.TickCount);
 
     private readonly Dictionary<string, Group> tileGroups = new();
     private string selectedGroup = string.Empty;
@@ -171,8 +186,11 @@ public class HeightMapGenerator : Window
             {
                 int sx = qx * quadWidth + (int)(x / (float)MapSize * quadWidth);
                 var c = heightMapTextureData[sy * heightMapWidth + sx];
-                float v = c.R / 255f;
-                int z = (int)MathF.Round(v * 254f - 127f);
+                int idx = Math.Clamp(c.R / (256 / NUM_CHANNELS), 0, NUM_CHANNELS - 1);
+                var range = HeightRanges[Math.Min(idx, HeightRanges.Length - 1)];
+                float n = noise.Fractal(x * NOISE_SCALE, y * NOISE_SCALE, NOISE_ROUGHNESS);
+                float t = (n + 1f) * 0.5f;
+                int z = (int)MathF.Round(range.Min + t * (range.Max - range.Min));
                 heightData[x, y] = (sbyte)Math.Clamp(z, -127, 127);
             }
         }
@@ -413,5 +431,64 @@ public class HeightMapGenerator : Window
         public sbyte MinHeight = -128;
         public sbyte MaxHeight = 127;
         public List<ushort> Ids = new();
+    }
+
+    private class Perlin
+    {
+        private readonly int[] p = new int[512];
+
+        public Perlin(int seed)
+        {
+            var perm = Enumerable.Range(0, 256).ToArray();
+            var rnd = new Random(seed);
+            for (int i = 0; i < 256; i++)
+            {
+                var j = rnd.Next(i, 256);
+                (perm[i], perm[j]) = (perm[j], perm[i]);
+                p[i] = perm[i];
+                p[i + 256] = perm[i];
+            }
+        }
+
+        private static float Fade(float t) => t * t * t * (t * (t * 6 - 15) + 10);
+        private static float Lerp(float t, float a, float b) => a + t * (b - a);
+        private static float Grad(int hash, float x, float y)
+        {
+            int h = hash & 3;
+            float u = h < 2 ? x : y;
+            float v = h < 2 ? y : x;
+            return ((h & 1) == 0 ? u : -u) + ((h & 2) == 0 ? v : -v);
+        }
+
+        public float Noise(float x, float y)
+        {
+            int xi = (int)MathF.Floor(x) & 255;
+            int yi = (int)MathF.Floor(y) & 255;
+            float xf = x - MathF.Floor(x);
+            float yf = y - MathF.Floor(y);
+            int a = p[xi] + yi;
+            int b = p[xi + 1] + yi;
+            float u = Fade(xf);
+            float v = Fade(yf);
+            return Lerp(v,
+                Lerp(u, Grad(p[a], xf, yf), Grad(p[b], xf - 1, yf)),
+                Lerp(u, Grad(p[a + 1], xf, yf - 1), Grad(p[b + 1], xf - 1, yf - 1)));
+        }
+
+        public float Fractal(float x, float y, float roughness)
+        {
+            float total = 0;
+            float amplitude = 1;
+            float frequency = 1;
+            float max = 0;
+            for (int i = 0; i < 4; i++)
+            {
+                total += Noise(x * frequency, y * frequency) * amplitude;
+                max += amplitude;
+                amplitude *= roughness;
+                frequency *= 2;
+            }
+            return total / max;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- define explicit height ranges for water, sand, grass, jungle, rock and snow
- apply Perlin noise generation within each range

## Testing
- `dotnet build CentrEDSharp.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848051e965c832fa872c19ea816c47e