### PR TITLE
Fix area size calculation

### DIFF
--- a/Shared/Network/AreaInfo.cs
+++ b/Shared/Network/AreaInfo.cs
@@ -13,8 +13,13 @@ public struct AreaInfo
         Bottom = bottom;
     }
     
-    public ushort Width => (ushort)(Right - Left);
-    public ushort Height => (ushort)(Bottom - Top);
+    // Include both boundaries when calculating the size so that
+    // callers requesting blocks for an inclusive area allocate
+    // enough space. The previous implementation subtracted the
+    // coordinates directly, which caused off-by-one errors and
+    // could evict neighbour blocks prematurely during generation.
+    public ushort Width => (ushort)(Right - Left + 1);
+    public ushort Height => (ushort)(Bottom - Top + 1);
 
     public AreaInfo(BinaryReader reader)
     {


### PR DESCRIPTION
## Summary
- fix off-by-one error in `AreaInfo` width/height calculations

## Testing
- `dotnet build -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482a6e9e1c832f835020e966a91b2e