### PR TITLE
Fix heightmap channel mapping

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator.cs
@@ -196,7 +196,8 @@ public class HeightMapGenerator : Window
                 int sx = qx * quadWidth + (int)(x / (float)MapSize * quadWidth);
                 var c = heightMapTextureData[sy * heightMapWidth + sx];
                 int rawIndex = c.R / (256 / NUM_CHANNELS);
-                idxMap[x, y] = Math.Clamp(rawIndex, 0, 1); // apenas água e areia
+                // Map the pixel value to the corresponding terrain channel
+                idxMap[x, y] = Math.Clamp(rawIndex, 0, NUM_CHANNELS - 1);
             }
         }
 


### PR DESCRIPTION
## Summary
- allow all heightmap channels when generating index map

## Testing
- `dotnet build CentrEDSharp.sln --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482df67768832f910dca151816ab42