### PR TITLE
Switch HeightMap generator to 2x2 blocks

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator.cs
@@ -85,11 +85,11 @@ public class HeightMapGenerator : Window
         }
 
         ImGui.Text("Quadrant");
-        for (int qy = 0; qy < 2; qy++)
+        for (int qy = 0; qy < 4; qy++)
         {
-            for (int qx = 0; qx < 2; qx++)
+            for (int qx = 0; qx < 4; qx++)
             {
-                int idx = qy * 2 + qx;
+                int idx = qy * 4 + qx;
                 bool check = selectedQuadrant == idx;
                 if (ImGui.Checkbox($"##q_{qy}_{qx}", ref check))
                 {
@@ -99,7 +99,7 @@ public class HeightMapGenerator : Window
                         UpdateHeightData();
                     }
                 }
-                if (qx < 1) ImGui.SameLine();
+                if (qx < 3) ImGui.SameLine();
             }
         }
 
@@ -175,10 +175,10 @@ public class HeightMapGenerator : Window
         if (heightMapTextureData == null)
             return;
 
-        int quadWidth = heightMapWidth / 2;
-        int quadHeight = heightMapHeight / 2;
-        int qx = selectedQuadrant % 2;
-        int qy = selectedQuadrant / 2;
+        int quadWidth = heightMapWidth / 4;
+        int quadHeight = heightMapHeight / 4;
+        int qx = selectedQuadrant % 4;
+        int qy = selectedQuadrant / 4;
 
         var groupsOrdered = tileGroups.Values.OrderBy(g => g.MinHeight).ToArray();
 
@@ -357,17 +357,17 @@ public class HeightMapGenerator : Window
             return;
         }
 
-        int stepX = width / 2;
-        int stepY = height / 2;
-        int remX = width % 2;
-        int remY = height % 2;
+        int stepX = width / 4;
+        int stepY = height / 4;
+        int remX = width % 4;
+        int remY = height % 4;
 
         int offY = startY;
-        for (int qy = 0; qy < 2; qy++)
+        for (int qy = 0; qy < 4; qy++)
         {
             int h = stepY + (qy < remY ? 1 : 0);
             int offX = startX;
-            for (int qx = 0; qx < 2; qx++)
+            for (int qx = 0; qx < 4; qx++)
             {
                 int w = stepX + (qx < remX ? 1 : 0);
                 GenerateFractalRegion(offX, offY, w, h, groupsList, total);

--- a/CentrED/UI/Windows/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator.cs
@@ -85,11 +85,11 @@ public class HeightMapGenerator : Window
         }
 
         ImGui.Text("Quadrant");
-        for (int qy = 0; qy < 3; qy++)
+        for (int qy = 0; qy < 2; qy++)
         {
-            for (int qx = 0; qx < 3; qx++)
+            for (int qx = 0; qx < 2; qx++)
             {
-                int idx = qy * 3 + qx;
+                int idx = qy * 2 + qx;
                 bool check = selectedQuadrant == idx;
                 if (ImGui.Checkbox($"##q_{qy}_{qx}", ref check))
                 {
@@ -99,7 +99,7 @@ public class HeightMapGenerator : Window
                         UpdateHeightData();
                     }
                 }
-                if (qx < 2) ImGui.SameLine();
+                if (qx < 1) ImGui.SameLine();
             }
         }
 
@@ -175,10 +175,10 @@ public class HeightMapGenerator : Window
         if (heightMapTextureData == null)
             return;
 
-        int quadWidth = heightMapWidth / 3;
-        int quadHeight = heightMapHeight / 3;
-        int qx = selectedQuadrant % 3;
-        int qy = selectedQuadrant / 3;
+        int quadWidth = heightMapWidth / 2;
+        int quadHeight = heightMapHeight / 2;
+        int qx = selectedQuadrant % 2;
+        int qy = selectedQuadrant / 2;
 
         var groupsOrdered = tileGroups.Values.OrderBy(g => g.MinHeight).ToArray();
 
@@ -357,17 +357,17 @@ public class HeightMapGenerator : Window
             return;
         }
 
-        int stepX = width / 3;
-        int stepY = height / 3;
-        int remX = width % 3;
-        int remY = height % 3;
+        int stepX = width / 2;
+        int stepY = height / 2;
+        int remX = width % 2;
+        int remY = height % 2;
 
         int offY = startY;
-        for (int qy = 0; qy < 3; qy++)
+        for (int qy = 0; qy < 2; qy++)
         {
             int h = stepY + (qy < remY ? 1 : 0);
             int offX = startX;
-            for (int qx = 0; qx < 3; qx++)
+            for (int qx = 0; qx < 2; qx++)
             {
                 int w = stepX + (qx < remX ? 1 : 0);
                 GenerateFractalRegion(offX, offY, w, h, groupsList, total);

--- a/Readme.md
+++ b/Readme.md
@@ -44,7 +44,7 @@ dotnet run --project examples/Example.HeightMapCLI \
 
 O caminho para o arquivo PNG define o mapa de altura, enquanto o `groups.json`
 opcional especifica grupos de tiles por faixa de elevação. O parâmetro
-`quadrante` permite selecionar qual região da imagem será utilizada (0 a 8).
+`quadrante` permite selecionar qual região da imagem será utilizada (0 a 3).
 
 
 ## Links úteis

--- a/Readme.md
+++ b/Readme.md
@@ -44,7 +44,7 @@ dotnet run --project examples/Example.HeightMapCLI \
 
 O caminho para o arquivo PNG define o mapa de altura, enquanto o `groups.json`
 opcional especifica grupos de tiles por faixa de elevação. O parâmetro
-`quadrante` permite selecionar qual região da imagem será utilizada (0 a 3).
+`quadrante` permite selecionar qual região da imagem será utilizada (0 a 15).
 
 
 ## Links úteis

--- a/examples/Example.HeightMapCLI/Program.cs
+++ b/examples/Example.HeightMapCLI/Program.cs
@@ -107,10 +107,10 @@ internal class HeightMapGeneratorCLI
 
     private void UpdateHeightData()
     {
-        int quadWidth = _image.Width / 2;
-        int quadHeight = _image.Height / 2;
-        int qx = _quadrant % 2;
-        int qy = _quadrant / 2;
+        int quadWidth = _image.Width / 4;
+        int quadHeight = _image.Height / 4;
+        int qx = _quadrant % 4;
+        int qy = _quadrant / 4;
 
         _heightData = new sbyte[MapSize, MapSize];
         int[,] idxMap = new int[MapSize, MapSize];
@@ -244,17 +244,17 @@ internal class HeightMapGeneratorCLI
             return;
         }
 
-        int stepX = width / 2;
-        int stepY = height / 2;
-        int remX = width % 2;
-        int remY = height % 2;
+        int stepX = width / 4;
+        int stepY = height / 4;
+        int remX = width % 4;
+        int remY = height % 4;
 
         int offY = startY;
-        for (int qy = 0; qy < 2; qy++)
+        for (int qy = 0; qy < 4; qy++)
         {
             int h = stepY + (qy < remY ? 1 : 0);
             int offX = startX;
-            for (int qx = 0; qx < 2; qx++)
+            for (int qx = 0; qx < 4; qx++)
             {
                 int w = stepX + (qx < remX ? 1 : 0);
                 GenerateFractalRegion(offX, offY, w, h, groupsList, total);

--- a/examples/Example.HeightMapCLI/Program.cs
+++ b/examples/Example.HeightMapCLI/Program.cs
@@ -107,10 +107,10 @@ internal class HeightMapGeneratorCLI
 
     private void UpdateHeightData()
     {
-        int quadWidth = _image.Width / 3;
-        int quadHeight = _image.Height / 3;
-        int qx = _quadrant % 3;
-        int qy = _quadrant / 3;
+        int quadWidth = _image.Width / 2;
+        int quadHeight = _image.Height / 2;
+        int qx = _quadrant % 2;
+        int qy = _quadrant / 2;
 
         _heightData = new sbyte[MapSize, MapSize];
         int[,] idxMap = new int[MapSize, MapSize];
@@ -244,17 +244,17 @@ internal class HeightMapGeneratorCLI
             return;
         }
 
-        int stepX = width / 3;
-        int stepY = height / 3;
-        int remX = width % 3;
-        int remY = height % 3;
+        int stepX = width / 2;
+        int stepY = height / 2;
+        int remX = width % 2;
+        int remY = height % 2;
 
         int offY = startY;
-        for (int qy = 0; qy < 3; qy++)
+        for (int qy = 0; qy < 2; qy++)
         {
             int h = stepY + (qy < remY ? 1 : 0);
             int offX = startX;
-            for (int qx = 0; qx < 3; qx++)
+            for (int qx = 0; qx < 2; qx++)
             {
                 int w = stepX + (qx < remX ? 1 : 0);
                 GenerateFractalRegion(offX, offY, w, h, groupsList, total);


### PR DESCRIPTION
## Summary
- update quadrant UI and math to handle a 2x2 grid
- adjust fractal generation recursion for 2x2 subdivision
- update example CLI accordingly
- clarify valid quadrant range in README

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build --no-restore` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484203c9d4832f9ae9a58fc38ef789