### PR TITLE
Notify when no groups configured for heightmap

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator.cs
@@ -59,6 +59,9 @@ public class HeightMapGenerator : Window
     private string selectedGroup = string.Empty;
     private string newGroupName = string.Empty;
 
+    private string _statusText = string.Empty;
+    private System.Numerics.Vector4 _statusColor = UIManager.Red;
+
     private Task? generationTask;
     private float generationProgress;
 
@@ -141,6 +144,10 @@ public class HeightMapGenerator : Window
             {
                 ImGui.ProgressBar(generationProgress, new System.Numerics.Vector2(-1, 0));
             }
+        }
+        if (!string.IsNullOrEmpty(_statusText))
+        {
+            ImGui.TextColored(_statusColor, _statusText);
         }
     }
 
@@ -324,11 +331,16 @@ public class HeightMapGenerator : Window
         if (generationTask != null && !generationTask.IsCompleted)
             return;
 
+        _statusText = string.Empty;
         generationTask = Task.Run(() =>
         {
             var groupsList = tileGroups.Values.Where(g => g.Ids.Count > 0).ToList();
             if (groupsList.Count == 0)
+            {
+                _statusText = "No groups configured.";
+                _statusColor = UIManager.Red;
                 return;
+            }
 
             var total = MapSize * MapSize;
             if (total > MaxTiles)

--- a/examples/Example.HeightMapCLI/Program.cs
+++ b/examples/Example.HeightMapCLI/Program.cs
@@ -36,6 +36,14 @@ if (File.Exists(groupsPath))
     groups = JsonSerializer.Deserialize<Dictionary<string, Group>>(File.ReadAllText(groupsPath), new JsonSerializerOptions { IncludeFields = true }) ?? new();
 }
 
+var groupsList = groups.Values.Where(g => g.Ids.Count > 0).ToList();
+if (groupsList.Count == 0)
+{
+    Console.WriteLine("No groups configured. Aborting.");
+    client.Disconnect();
+    return;
+}
+
 HeightMapGeneratorCLI generator = new(client, image, groups, quadrant);
 Console.WriteLine("Generating...");
 generator.Generate();
@@ -86,7 +94,10 @@ internal class HeightMapGeneratorCLI
 
         var groupsList = _groups.Values.Where(g => g.Ids.Count > 0).ToList();
         if (groupsList.Count == 0)
+        {
+            Console.WriteLine("No groups configured. Aborting.");
             return;
+        }
 
         var total = MapSize * MapSize;
         if (total > MaxTiles)


### PR DESCRIPTION
## Summary
- display a message in `HeightMapGenerator` window when no groups are configured
- notify and abort in CLI heightmap example if no groups are found

## Testing
- `dotnet build CentrEDSharp.sln -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848484982fc832f84b9e5b86471c5c9