### PR TITLE
Fix heightmap biomes indexing

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator.cs
@@ -203,8 +203,9 @@ public class HeightMapGenerator : Window
             {
                 int sx = qx * quadWidth + (int)(x / (float)MapSizeX * quadWidth);
                 var c = heightMapTextureData[sy * heightMapWidth + sx];
-                int rawIndex = c.R / (256 / NUM_CHANNELS);
-                // Map the pixel value to the corresponding terrain channel
+                // Use average brightness so coloured heightmaps work as well
+                float brightness = (c.R + c.G + c.B) / 3f;
+                int rawIndex = (int)(brightness / (256f / NUM_CHANNELS));
                 idxMap[x, y] = Math.Clamp(rawIndex, 0, NUM_CHANNELS - 1);
             }
         }

--- a/examples/Example.HeightMapCLI/Program.cs
+++ b/examples/Example.HeightMapCLI/Program.cs
@@ -133,7 +133,8 @@ internal class HeightMapGeneratorCLI
             {
                 int sx = qx * quadWidth + (int)(x / (float)MapSizeX * quadWidth);
                 var c = _image[sx, sy];
-                int rawIndex = c.R / (256 / NUM_CHANNELS);
+                float brightness = (c.R + c.G + c.B) / 3f;
+                int rawIndex = (int)(brightness / (256f / NUM_CHANNELS));
                 idxMap[x, y] = Math.Clamp(rawIndex, 0, NUM_CHANNELS - 1);
             }
         }


### PR DESCRIPTION
## Summary
- interpret heightmap pixel colors by brightness instead of red channel
- update the CLI sample to use the same logic

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848a3359f60832f94522c62157b2632