### PR TITLE
Skip smoothing for jungle to rock transitions

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator.cs
@@ -344,6 +344,9 @@ public class HeightMapGenerator : Window
                     int dist = distMap[x, y];
                     if (dist > SMOOTH_RADIUS) continue;
 
+                    if (src == 3 && idxMap[x, y] == src + 1)
+                        continue; // no smoothing from jungle to rock
+
                     int z;
                     if (dist <= 1)
                         z = HeightRanges[src].Max;

--- a/examples/Example.HeightMapCLI/Program.cs
+++ b/examples/Example.HeightMapCLI/Program.cs
@@ -273,6 +273,9 @@ internal class HeightMapGeneratorCLI
                     int dist = distMap[x, y];
                     if (dist > SMOOTH_RADIUS) continue;
 
+                    if (src == 3 && idxMap[x, y] == src + 1)
+                        continue; // no smoothing from jungle to rock
+
                     int z;
                     if (dist <= 1)
                         z = HeightRanges[src].Max;


### PR DESCRIPTION
## Summary
- avoid smoothing transitions between jungle and rock biomes so rock forms sharp mountains
- update CLI example with the same logic

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b58da4c0832f973b65197b2ce2f8