### PR TITLE
Fix reversed transition direction in land brush

### DIFF
--- a/CentrED/Tools/LandBrushTool.cs
+++ b/CentrED/Tools/LandBrushTool.cs
@@ -215,8 +215,8 @@ public class LandBrushTool : BaseTool
                     {
                         if (activeBrush.TryGetMinimalTransition(currentTileBrush.Name, reversedTransition, out targetTransition))
                         {
-                            // We have inverse the transition direction to get real result
-                            result = ~targetTransition.Direction;
+                            // Reverse the direction of the found transition so it matches the original request
+                            result = targetTransition.Direction.Reverse();
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- correct reversed transition logic in `LandBrushTool`

## Testing
- `dotnet test --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e838c60c832fae6ca071a9d542f0