### PR TITLE
Fix smoothing artifacts near biome boundaries

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator.cs
@@ -340,7 +340,7 @@ public class HeightMapGenerator : Window
             {
                 for (int x = 0; x < MapSizeX; x++)
                 {
-                    if (idxMap[x, y] <= src) continue;
+                    if (idxMap[x, y] != src + 1) continue;
                     int dist = distMap[x, y];
                     if (dist > SMOOTH_RADIUS) continue;
 
@@ -411,7 +411,7 @@ public class HeightMapGenerator : Window
             {
                 for (int x = 0; x < MapSizeX; x++)
                 {
-                    if (idxMap[x, y] >= src) continue;
+                    if (idxMap[x, y] != src - 1) continue;
                     int dist = distMap[x, y];
                     if (dist > SMOOTH_RADIUS) continue;
 


### PR DESCRIPTION
## Summary
- improve biome smoothing logic by only processing adjacent biome indices

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ed20fff0832fae05a557fcf85839