### PR TITLE
Fix reverse transition recursion

### DIFF
--- a/CentrED/Tools/LandBrushTool.cs
+++ b/CentrED/Tools/LandBrushTool.cs
@@ -217,6 +217,13 @@ public class LandBrushTool : BaseTool
                         {
                             // Reverse the direction of the found transition so it matches the original request
                             result = targetTransition.Direction.Reverse();
+
+                            // Ensure tile is recognised as the reversed transition on subsequent passes
+                            if (!_manager.tileToLandBrushNames.TryGetValue(targetTransition.TileID, out var reverseList)
+                                || !reverseList.Contains((currentTileBrush.Name, activeBrush.Name)))
+                            {
+                                _manager.AddLandBrushEntry(targetTransition.TileID, currentTileBrush.Name, activeBrush.Name);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure reversed land transitions are recognized by adding an entry for the new orientation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493c0949ac832fa5a90549610ed770