### PR TITLE
Fix duplicate SaveGroups method

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawGroups.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawGroups.cs
@@ -95,5 +95,4 @@ public partial class HeightMapGenerator
         }
     }
 
-    private void SaveGroups() => SaveGroups(groupsPath);
 }


### PR DESCRIPTION
## Summary
- remove duplicate SaveGroups definition from `HeightMapGenerator.DrawGroups`

## Testing
- `dotnet build CentrEDSharp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849412fa3f8832f845a8035939ae89a