### PR TITLE
Fix water height smoothing issue

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.UpdateHeightData.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.UpdateHeightData.cs
@@ -266,6 +266,17 @@ public partial class HeightMapGenerator
                     heightData[x, y] = (sbyte)Math.Clamp(z, -127, 127);
                 }
             }
+
+        }
+
+        // Ensure water tiles remain at the baseline height after smoothing
+        for (int y = 0; y < MapSizeY; y++)
+        {
+            for (int x = 0; x < MapSizeX; x++)
+            {
+                if (idxMap[x, y] == 0)
+                    heightData[x, y] = -127;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure water height stays at -127 after applying heightmap smoothing

## Testing
- `dotnet build CentrEDSharp.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849458b1ee0832f9880ec2a10e3274c