### PR TITLE
Enable transition tile editing in HeightMapGenerator

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitions.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitions.cs
@@ -1,0 +1,60 @@
+using ImGuiNET;
+using System.Numerics;
+
+namespace CentrED.UI.Windows;
+
+public partial class HeightMapGenerator
+{
+    private void DrawTransitions(Dictionary<string, Tile[]> transitions, ref string selected)
+    {
+        if (ImGui.BeginChild("TransitionList", new Vector2(0, 120), ImGuiChildFlags.Borders))
+        {
+            foreach (var kv in transitions)
+            {
+                bool isSel = selected == kv.Key;
+                if (ImGui.Selectable(kv.Key, isSel))
+                    selected = kv.Key;
+            }
+            ImGui.EndChild();
+        }
+
+        if (!string.IsNullOrEmpty(selected) && transitions.TryGetValue(selected, out var tiles))
+        {
+            if (ImGui.BeginChild($"{selected}_tiles", new Vector2(0, 120), ImGuiChildFlags.Borders))
+            {
+                for (int row = 0; row < 3; row++)
+                {
+                    for (int col = 0; col < 3; col++)
+                    {
+                        int idx = row * 3 + col;
+                        var tile = tiles[idx];
+                        string label = tile.Id != 0 ? $"0x{tile.Id:X4}" : "---";
+                        ImGui.PushID(idx);
+                        if (ImGui.SmallButton(label))
+                        {
+                            tiles[idx] = new Tile(tile.Type, 0);
+                        }
+                        if (ImGui.BeginDragDropTarget())
+                        {
+                            var payloadPtr = ImGui.AcceptDragDropPayload(TilesWindow.Land_DragDrop_Target_Type);
+                            unsafe
+                            {
+                                if (payloadPtr.NativePtr != null)
+                                {
+                                    var dataPtr = (int*)payloadPtr.Data;
+                                    ushort id = (ushort)dataPtr[0];
+                                    tiles[idx] = new Tile(tile.Type, id);
+                                }
+                            }
+                            ImGui.EndDragDropTarget();
+                        }
+                        ImGui.PopID();
+                        if (col < 2)
+                            ImGui.SameLine();
+                    }
+                }
+                ImGui.EndChild();
+            }
+        }
+    }
+}

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.InternalDraw.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.InternalDraw.cs
@@ -77,6 +77,9 @@ public partial class HeightMapGenerator
             }
         }
         ImGui.Separator();
+        ImGui.Text("Transition Tiles");
+        DrawTransitions(transitionTiles, ref selectedTransition);
+        ImGui.Separator();
 
         ImGui.BeginDisabled(heightData == null || generationTask != null && !generationTask.IsCompleted);
         if (ImGui.Button("Generate"))

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
@@ -66,6 +66,7 @@ public partial class HeightMapGenerator : Window
         ["rock-snow"] = new Tile[9]
     };
     private string selectedGroup = string.Empty;
+    private string selectedTransition = string.Empty;
     private string newGroupName = string.Empty;
 
     private string _statusText = string.Empty;


### PR DESCRIPTION
## Summary
- allow choosing a transition tile set
- show 3x3 grid for transition tiles and drop tiles onto each slot

## Testing
- `dotnet build CentrEDSharp.sln -v:m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495f56b2f4832f99a0979fe7182a4f