### PR TITLE
Add transition tile groups save/load

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.InternalDraw.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.InternalDraw.cs
@@ -79,6 +79,21 @@ public partial class HeightMapGenerator
         ImGui.Separator();
         ImGui.Text("Transition Tiles");
         DrawTransitions(transitionTiles, ref selectedTransition);
+        if (ImGui.Button("Save Transitions"))
+        {
+            if (TinyFileDialogs.TrySaveFile("Save Transitions", transitionsPath, new[] { "*.json" }, "JSON Files", out var path))
+            {
+                SaveTransitions(path);
+            }
+        }
+        ImGui.SameLine();
+        if (ImGui.Button("Load Transitions"))
+        {
+            if (TinyFileDialogs.TryOpenFile("Load Transitions", Environment.CurrentDirectory, new[] { "*.json" }, "JSON Files", false, out var path))
+            {
+                LoadTransitions(path);
+            }
+        }
         ImGui.Separator();
 
         ImGui.BeginDisabled(heightData == null || generationTask != null && !generationTask.IsCompleted);

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitions.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text.Json;
+using CentrED.Client;
+using CentrED.Client.Map;
+using CentrED.IO.Models;
+using CentrED.Network;
+using ImGuiNET;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using static CentrED.Application;
+
+namespace CentrED.UI.Windows;
+
+public partial class HeightMapGenerator
+{
+    private void LoadTransitions() => LoadTransitions(transitionsPath);
+}

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitionsPath.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitionsPath.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text.Json;
+using CentrED.Client;
+using CentrED.Client.Map;
+using CentrED.IO.Models;
+using CentrED.Network;
+using ImGuiNET;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using static CentrED.Application;
+
+namespace CentrED.UI.Windows;
+
+public partial class HeightMapGenerator
+{
+    private void LoadTransitions(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return;
+            var data = JsonSerializer.Deserialize<Dictionary<string, Tile[]>>(File.ReadAllText(path), new JsonSerializerOptions
+            {
+                IncludeFields = true
+            });
+            if (data == null)
+                return;
+            transitionTiles.Clear();
+            foreach (var kv in data)
+                transitionTiles[kv.Key] = kv.Value;
+            transitionsPath = path;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"Failed to load transitions: {e.Message}");
+        }
+    }
+}

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.SaveTransitions.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.SaveTransitions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text.Json;
+using CentrED.Client;
+using CentrED.Client.Map;
+using CentrED.IO.Models;
+using CentrED.Network;
+using ImGuiNET;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using static CentrED.Application;
+
+namespace CentrED.UI.Windows;
+
+public partial class HeightMapGenerator
+{
+    private void SaveTransitions() => SaveTransitions(transitionsPath);
+}

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.SaveTransitionsPath.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.SaveTransitionsPath.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text.Json;
+using CentrED.Client;
+using CentrED.Client.Map;
+using CentrED.IO.Models;
+using CentrED.Network;
+using ImGuiNET;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using static CentrED.Application;
+
+namespace CentrED.UI.Windows;
+
+public partial class HeightMapGenerator
+{
+    private void SaveTransitions(string path)
+    {
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            IncludeFields = true
+        };
+        File.WriteAllText(path, JsonSerializer.Serialize(transitionTiles, options));
+        transitionsPath = path;
+    }
+}

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
@@ -30,6 +30,7 @@ public partial class HeightMapGenerator : Window
     private const int BlockSize = 256;
     private const int MaxTiles = 16 * 1024 * 1024;
     private const string GroupsFile = "heightmap_groups.json";
+    private const string TransitionsFile = "heightmap_transitions.json";
 
     private static readonly (sbyte Min, sbyte Max)[] HeightRanges =
     {
@@ -46,6 +47,7 @@ public partial class HeightMapGenerator : Window
     private const int SMOOTH_RADIUS = 64;
 
     private string groupsPath = GroupsFile;
+    private string transitionsPath = TransitionsFile;
 
     private string heightMapPath = string.Empty;
     private sbyte[,]? heightData;


### PR DESCRIPTION
## Summary
- enable saving/loading of transition tiles
- hook up UI for handling JSON files

## Testing
- `dotnet build CentrEDSharp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849610b5ee0832f9cbd3ec604d75bd5