### PR TITLE
Add transition application after height data update

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.BuildTileMap.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.BuildTileMap.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+
+namespace CentrED.UI.Windows;
+
+public partial class HeightMapGenerator
+{
+    private void BuildTileMap()
+    {
+        if (heightData == null)
+            return;
+
+        var groupsList = tileGroups.Values.Where(g => g.Ids.Count > 0).ToList();
+        if (groupsList.Count == 0)
+            return;
+
+        tileMap = new Tile[MapSizeX, MapSizeY];
+        for (int y = 0; y < MapSizeY; y++)
+        {
+            for (int x = 0; x < MapSizeX; x++)
+            {
+                var z = heightData[x, y];
+                var candidates = groupsList.Where(g => z >= g.MinHeight && z <= g.MaxHeight).ToList();
+                if (candidates.Count == 0)
+                    candidates = groupsList;
+                var grp = SelectGroup(candidates);
+                ushort id = grp.Ids.Count > 0 ? grp.Ids[Random.Shared.Next(grp.Ids.Count)] : (ushort)0;
+                tileMap[x, y] = new Tile(GetTerrainType(z), id);
+            }
+        }
+
+        transitionConverter.ApplyTransitions(tileMap, transitionTiles);
+    }
+
+    private static TerrainType GetTerrainType(sbyte z)
+    {
+        for (int i = 0; i < HeightRanges.Length; i++)
+        {
+            var r = HeightRanges[i];
+            if (z >= r.Min && z <= r.Max)
+                return (TerrainType)i;
+        }
+        return TerrainType.Water;
+    }
+}

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.GenerateArea.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.GenerateArea.cs
@@ -38,15 +38,29 @@ public partial class HeightMapGenerator
                         if (!CEDClient.TryGetLandTile(x, y, out var landTile))
                             continue;
                         var z = heightData[x, y];
-                        var candidates = groupsList.Where(g => z >= g.MinHeight && z <= g.MaxHeight).ToList();
-                        if (candidates.Count == 0)
-                            candidates = groupsList;
-                        if (candidates.Count > 0)
+                        ushort id;
+                        if (tileMap != null)
                         {
-                            var grp = SelectGroup(candidates);
-                            var id = grp.Ids[Random.Shared.Next(grp.Ids.Count)];
-                            landTile.ReplaceLand(id, z);
+                            id = tileMap[x, y].Id;
                         }
+                        else
+                        {
+                            var candidates = groupsList.Where(g => z >= g.MinHeight && z <= g.MaxHeight).ToList();
+                            if (candidates.Count == 0)
+                                candidates = groupsList;
+                            if (candidates.Count > 0)
+                            {
+                                var grp = SelectGroup(candidates);
+                                id = grp.Ids[Random.Shared.Next(grp.Ids.Count)];
+                            }
+                            else
+                            {
+                                id = 0;
+                            }
+                        }
+                        if (id != 0)
+                            landTile.ReplaceLand(id, z);
+                        
                         generationProgress += 1f / total;
                         if (ct.IsCancellationRequested)
                             break;

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.UpdateHeightData.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.UpdateHeightData.cs
@@ -27,7 +27,6 @@ public partial class HeightMapGenerator
         int qx = selectedQuadrant % 3;
         int qy = selectedQuadrant / 3;
 
-        var groupsOrdered = tileGroups.Values.OrderBy(g => g.MinHeight).ToArray();
 
         heightData = new sbyte[MapSizeX, MapSizeY];
 
@@ -278,6 +277,8 @@ public partial class HeightMapGenerator
                     heightData[x, y] = -127;
             }
         }
+
+        BuildTileMap();
     }
 
 }

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
@@ -51,6 +51,7 @@ public partial class HeightMapGenerator : Window
 
     private string heightMapPath = string.Empty;
     private sbyte[,]? heightData;
+    private Tile[,]? tileMap;
     private Color[]? heightMapTextureData;
     private int heightMapWidth;
     private int heightMapHeight;


### PR DESCRIPTION
## Summary
- generate tile map after height data is built
- apply transition tiles without altering height
- use precomputed tile map when generating blocks

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496fd35ba8832f8ef7abc6eab748d6