### PR TITLE
Add x1/x2/y1/y2 coordinates for heightmap generator

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.BuildTileMap.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.BuildTileMap.cs
@@ -13,10 +13,10 @@ public partial class HeightMapGenerator
         if (groupsList.Count == 0)
             return;
 
-        tileMap = new Tile[mapSizeX, mapSizeY];
-        for (int y = 0; y < mapSizeY; y++)
+        tileMap = new Tile[MapSizeX, MapSizeY];
+        for (int y = 0; y < MapSizeY; y++)
         {
-            for (int x = 0; x < mapSizeX; x++)
+            for (int x = 0; x < MapSizeX; x++)
             {
                 var z = heightData[x, y];
                 var candidates = groupsList.Where(g => z >= g.MinHeight && z <= g.MaxHeight).ToList();

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.Generate.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.Generate.cs
@@ -39,13 +39,13 @@ public partial class HeightMapGenerator
                 return;
             }
 
-            var total = mapSizeX * mapSizeY;
+            var total = MapSizeX * MapSizeY;
             if (total > MaxTiles)
                 return;
             CEDClient.BulkMode = true;
             try
             {
-                GenerateFractalRegion(0, 0, mapSizeX, mapSizeY, groupsList, total, token);
+                GenerateFractalRegion(x1, y1, MapSizeX, MapSizeY, groupsList, total, token);
             }
             finally
             {

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.GenerateArea.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.GenerateArea.cs
@@ -21,8 +21,8 @@ public partial class HeightMapGenerator
 
     private void GenerateArea(int startX, int startY, int width, int height, List<Group> groupsList, float total, CancellationToken ct)
     {
-        int endX = Math.Min(mapSizeX - 1, startX + width - 1);
-        int endY = Math.Min(mapSizeY - 1, startY + height - 1);
+        int endX = startX + width - 1;
+        int endY = startY + height - 1;
 
         for (int bx = startX; bx <= endX && !ct.IsCancellationRequested; bx += BlockSize)
         {
@@ -37,11 +37,11 @@ public partial class HeightMapGenerator
                     {
                         if (!CEDClient.TryGetLandTile(x, y, out var landTile))
                             continue;
-                        var z = heightData[x, y];
+                        var z = heightData[x - x1, y - y1];
                         ushort id;
                         if (tileMap != null)
                         {
-                            id = tileMap[x, y].Id;
+                            id = tileMap[x - x1, y - y1].Id;
                         }
                         else
                         {

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.InternalDraw.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.InternalDraw.cs
@@ -39,11 +39,15 @@ public partial class HeightMapGenerator
             ImGui.Text($"Loaded: {Path.GetFileName(heightMapPath)}");
         }
 
-        int prevX = mapSizeX;
-        int prevY = mapSizeY;
-        ImGui.InputInt("Width", ref mapSizeX);
-        ImGui.InputInt("Height", ref mapSizeY);
-        if (mapSizeX != prevX || mapSizeY != prevY)
+        int prevX1 = x1;
+        int prevX2 = x2;
+        int prevY1 = y1;
+        int prevY2 = y2;
+        ImGui.InputInt("X1", ref x1);
+        ImGui.InputInt("X2", ref x2);
+        ImGui.InputInt("Y1", ref y1);
+        ImGui.InputInt("Y2", ref y2);
+        if (x1 != prevX1 || x2 != prevX2 || y1 != prevY1 || y2 != prevY2)
             UpdateHeightData();
 
         ImGui.Text("Quadrant");

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.UpdateHeightData.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.UpdateHeightData.cs
@@ -28,7 +28,7 @@ public partial class HeightMapGenerator
         int qy = selectedQuadrant / 3;
 
 
-        heightData = new sbyte[mapSizeX, mapSizeY];
+        heightData = new sbyte[MapSizeX, MapSizeY];
 
         // ---------------------------
         // 1. Primeiro passo: calcular idx para todos os pixels
@@ -65,13 +65,13 @@ public partial class HeightMapGenerator
             }
         }
 
-        int[,] idxMap = new int[mapSizeX, mapSizeY];
-        for (int y = 0; y < mapSizeY; y++)
+        int[,] idxMap = new int[MapSizeX, MapSizeY];
+        for (int y = 0; y < MapSizeY; y++)
         {
-            int sy = qy * quadHeight + (int)(y / (float)mapSizeY * quadHeight);
-            for (int x = 0; x < mapSizeX; x++)
+            int sy = qy * quadHeight + (int)(y / (float)MapSizeY * quadHeight);
+            for (int x = 0; x < MapSizeX; x++)
             {
-                int sx = qx * quadWidth + (int)(x / (float)mapSizeX * quadWidth);
+                int sx = qx * quadWidth + (int)(x / (float)MapSizeX * quadWidth);
                 var c = heightMapTextureData[sy * heightMapWidth + sx];
                 int brightness = (int)MathF.Round((c.R + c.G + c.B) / 3f);
                 idxMap[x, y] = palette[Math.Clamp(brightness, 0, 255)];
@@ -81,9 +81,9 @@ public partial class HeightMapGenerator
         // ---------------------------
         // 2. Primeiro passo: gerar altura base sem suavização
         // ---------------------------
-        for (int y = 0; y < mapSizeY; y++)
+        for (int y = 0; y < MapSizeY; y++)
         {
-            for (int x = 0; x < mapSizeX; x++)
+            for (int x = 0; x < MapSizeX; x++)
             {
                 int idx = idxMap[x, y];
                 var range = HeightRanges[idx];
@@ -93,12 +93,12 @@ public partial class HeightMapGenerator
                 for (int dy = -1; dy <= 1 && !isEdge; dy++)
                 {
                     int ny = y + dy;
-                    if (ny < 0 || ny >= mapSizeY) continue;
+                    if (ny < 0 || ny >= MapSizeY) continue;
                     for (int dx = -1; dx <= 1; dx++)
                     {
                         if (dx == 0 && dy == 0) continue;
                         int nx = x + dx;
-                        if (nx < 0 || nx >= mapSizeX) continue;
+                        if (nx < 0 || nx >= MapSizeX) continue;
                         if (idxMap[nx, ny] != idx)
                         {
                             isEdge = true;
@@ -113,12 +113,12 @@ public partial class HeightMapGenerator
                 }
                 else
                 {
-                    float n = noise.Fractal(x * NOISE_SCALE, y * NOISE_SCALE, NOISE_ROUGHNESS);
+                    float n = noise.Fractal((x1 + x) * NOISE_SCALE, (y1 + y) * NOISE_SCALE, NOISE_ROUGHNESS);
                     float t = (n + 1f) * 0.5f;
                     z = (int)MathF.Round(range.Min + t * (range.Max - range.Min));
                     if (isEdge)
                     {
-                        float edgePerturb = noise.Noise(x * 0.3f, y * 0.3f);
+                        float edgePerturb = noise.Noise((x1 + x) * 0.3f, (y1 + y) * 0.3f);
                         z += (int)(edgePerturb * 3);
                     }
                 }
@@ -132,11 +132,11 @@ public partial class HeightMapGenerator
         // ---------------------------
         for (int src = 0; src < NUM_CHANNELS - 1; src++)
         {
-            int[,] distMap = new int[mapSizeX, mapSizeY];
+            int[,] distMap = new int[MapSizeX, MapSizeY];
             var queue = new Queue<(int X, int Y)>();
-            for (int y = 0; y < mapSizeY; y++)
+            for (int y = 0; y < MapSizeY; y++)
             {
-                for (int x = 0; x < mapSizeX; x++)
+                for (int x = 0; x < MapSizeX; x++)
                 {
                     if (idxMap[x, y] == src)
                     {
@@ -159,12 +159,12 @@ public partial class HeightMapGenerator
                 for (int dy = -1; dy <= 1; dy++)
                 {
                     int ny = cy + dy;
-                    if (ny < 0 || ny >= mapSizeY) continue;
+                    if (ny < 0 || ny >= MapSizeY) continue;
                     for (int dx = -1; dx <= 1; dx++)
                     {
                         if (dx == 0 && dy == 0) continue;
                         int nx = cx + dx;
-                        if (nx < 0 || nx >= mapSizeX) continue;
+                        if (nx < 0 || nx >= MapSizeX) continue;
                         if (nd < distMap[nx, ny])
                         {
                             distMap[nx, ny] = nd;
@@ -174,9 +174,9 @@ public partial class HeightMapGenerator
                 }
             }
 
-            for (int y = 0; y < mapSizeY; y++)
+            for (int y = 0; y < MapSizeY; y++)
             {
-                for (int x = 0; x < mapSizeX; x++)
+                for (int x = 0; x < MapSizeX; x++)
                 {
                     if (idxMap[x, y] != src + 1) continue;
                     int dist = distMap[x, y];
@@ -201,11 +201,11 @@ public partial class HeightMapGenerator
         // Segunda passada para suavizar o lado oposto das bordas
         for (int src = NUM_CHANNELS - 1; src > 0; src--)
         {
-            int[,] distMap = new int[mapSizeX, mapSizeY];
+            int[,] distMap = new int[MapSizeX, MapSizeY];
             var queue = new Queue<(int X, int Y)>();
-            for (int y = 0; y < mapSizeY; y++)
+            for (int y = 0; y < MapSizeY; y++)
             {
-                for (int x = 0; x < mapSizeX; x++)
+                for (int x = 0; x < MapSizeX; x++)
                 {
                     if (idxMap[x, y] == src)
                     {
@@ -228,12 +228,12 @@ public partial class HeightMapGenerator
                 for (int dy = -1; dy <= 1; dy++)
                 {
                     int ny = cy + dy;
-                    if (ny < 0 || ny >= mapSizeY) continue;
+                    if (ny < 0 || ny >= MapSizeY) continue;
                     for (int dx = -1; dx <= 1; dx++)
                     {
                         if (dx == 0 && dy == 0) continue;
                         int nx = cx + dx;
-                        if (nx < 0 || nx >= mapSizeX) continue;
+                        if (nx < 0 || nx >= MapSizeX) continue;
                         if (nd < distMap[nx, ny])
                         {
                             distMap[nx, ny] = nd;
@@ -243,9 +243,9 @@ public partial class HeightMapGenerator
                 }
             }
 
-            for (int y = 0; y < mapSizeY; y++)
+            for (int y = 0; y < MapSizeY; y++)
             {
-                for (int x = 0; x < mapSizeX; x++)
+                for (int x = 0; x < MapSizeX; x++)
                 {
                     if (idxMap[x, y] != src - 1) continue;
                     int dist = distMap[x, y];
@@ -269,9 +269,9 @@ public partial class HeightMapGenerator
         }
 
         // Ensure water tiles remain at the baseline height after smoothing
-        for (int y = 0; y < mapSizeY; y++)
+        for (int y = 0; y < MapSizeY; y++)
         {
-            for (int x = 0; x < mapSizeX; x++)
+            for (int x = 0; x < MapSizeX; x++)
             {
                 if (idxMap[x, y] == 0)
                     heightData[x, y] = -127;

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
@@ -25,8 +25,12 @@ public partial class HeightMapGenerator : Window
         IsOpen = false
     };
 
-    private int mapSizeX = 4096;
-    private int mapSizeY = 4096;
+    private int x1 = 0;
+    private int y1 = 0;
+    private int x2 = 4095;
+    private int y2 = 4095;
+    private int MapSizeX => x2 - x1 + 1;
+    private int MapSizeY => y2 - y1 + 1;
     private const int BlockSize = 256;
     private const int MaxTiles = 16 * 1024 * 1024;
     private const string GroupsFile = "heightmap_groups.json";


### PR DESCRIPTION
## Summary
- allow selecting start and end coordinates for the heightmap generator
- compute map size from selected coordinates
- draw region using offsets

## Testing
- `dotnet build CentrEDSharp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a4828dbc832f901161e95142ef4d