### PR TITLE
Fix unused transition tiles causing double black space

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.TransitionConverter.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.TransitionConverter.cs
@@ -109,7 +109,9 @@ public partial class HeightMapGenerator
                     var key = $"{center.Type.ToString().ToLower()}-{bType.ToString().ToLower()}";
                     if (transitionTiles.TryGetValue(key, out var tiles) && tiles.Length == 9)
                     {
-                        map[x, y] = tiles[bestIndex];
+                        var tile = tiles[bestIndex];
+                        if (tile.Id != 0)
+                            map[x, y] = tile;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- avoid applying height map transition tiles when they are blank

## Testing
- `dotnet build CentrEDSharp.sln -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849baaf6d3c832f8a4ce6ea10b2f52e