### PR TITLE
Fix transition orientation counting in HeightMapGenerator

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.TransitionConverter.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.TransitionConverter.cs
@@ -97,7 +97,21 @@ public partial class HeightMapGenerator
                         if (t.Type == bType)
                         {
                             int idx = kv.Value;
-                            int count = 1;
+                            int count = 0;
+                            for (int ndy = -1; ndy <= 1; ndy++)
+                            {
+                                for (int ndx = -1; ndx <= 1; ndx++)
+                                {
+                                    if (ndx == 0 && ndy == 0)
+                                        continue;
+                                    int nx = x + dx + ndx;
+                                    int ny = y + dy + ndy;
+                                    if (nx < 0 || nx >= width || ny < 0 || ny >= height)
+                                        continue;
+                                    if (copy[nx, ny].Type == bType)
+                                        count++;
+                                }
+                            }
                             if (count > bestCount)
                             {
                                 bestCount = count;


### PR DESCRIPTION
## Summary
- refine TransitionConverter to count surrounding bType tiles
- choose the tile orientation with the highest adjacent count

## Testing
- `dotnet build CentrEDSharp.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c7fb9fe0832f9227d75476eecbc8