### PR TITLE
Refactor transition system to DragonMod patterns

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitions.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitions.cs
@@ -7,7 +7,7 @@ namespace CentrED.UI.Windows;
 
 public partial class HeightMapGenerator
 {
-    private void DrawTransitions(Dictionary<string, Tile[]> transitions, ref string selected)
+    private void DrawTransitions(Dictionary<string, Dictionary<string, TransitionTile>> transitions, ref string selected)
     {
         if (ImGui.BeginChild("TransitionList", new Vector2(0, 120), ImGuiChildFlags.Borders))
         {
@@ -20,52 +20,50 @@ public partial class HeightMapGenerator
             ImGui.EndChild();
         }
 
-        if (!string.IsNullOrEmpty(selected) && transitions.TryGetValue(selected, out var tiles))
+        if (!string.IsNullOrEmpty(selected) && transitions.TryGetValue(selected, out var dict))
         {
             if (ImGui.BeginChild($"{selected}_tiles", new Vector2(0, 120), ImGuiChildFlags.Borders))
             {
-                for (int row = 0; row < 3; row++)
+                foreach (var kv in dict.ToArray())
                 {
-                    for (int col = 0; col < 3; col++)
+                    var pattern = kv.Key;
+                    var tile = kv.Value;
+                    ImGui.PushID(pattern);
+                    ImGui.Text(pattern);
+                    ImGui.SameLine();
+                    string label = tile.Id != 0 ? $"0x{tile.Id:X4}" : "---";
+                    if (tile.Id != 0)
                     {
-                        int idx = row * 3 + col;
-                        var tile = tiles[idx];
-                        string label = tile.Id != 0 ? $"0x{tile.Id:X4}" : "---";
-                        ImGui.PushID(idx);
-                        if (tile.Id != 0)
+                        var tex = CalculateButtonTexture((ushort)tile.Id);
+                        if (ImGui.ImageButton("tile", tex.texPtr, new Vector2(44, 44), tex.uv0, tex.uv1))
                         {
-                            var tex = CalculateButtonTexture(tile.Id);
-                            if (ImGui.ImageButton("tile", tex.texPtr, new Vector2(44, 44), tex.uv0, tex.uv1))
-                            {
-                                tiles[idx] = new Tile(tile.Type, 0);
-                            }
-                            UIManager.Tooltip(label);
+                            tile.Id = 0;
+                            dict[pattern] = tile;
                         }
-                        else
-                        {
-                            if (ImGui.Button("---", new Vector2(44, 44)))
-                            {
-                                // already empty, nothing to do
-                            }
-                        }
-                        if (ImGui.BeginDragDropTarget())
-                        {
-                            var payloadPtr = ImGui.AcceptDragDropPayload(TilesWindow.Land_DragDrop_Target_Type);
-                            unsafe
-                            {
-                                if (payloadPtr.NativePtr != null)
-                                {
-                                    var dataPtr = (int*)payloadPtr.Data;
-                                    ushort id = (ushort)dataPtr[0];
-                                    tiles[idx] = new Tile(tile.Type, id);
-                                }
-                            }
-                            ImGui.EndDragDropTarget();
-                        }
-                        ImGui.PopID();
-                        if (col < 2)
-                            ImGui.SameLine();
+                        UIManager.Tooltip(label);
                     }
+                    else
+                    {
+                        if (ImGui.Button("---", new Vector2(44, 44)))
+                        {
+                        }
+                    }
+                    if (ImGui.BeginDragDropTarget())
+                    {
+                        var payloadPtr = ImGui.AcceptDragDropPayload(TilesWindow.Land_DragDrop_Target_Type);
+                        unsafe
+                        {
+                            if (payloadPtr.NativePtr != null)
+                            {
+                                var dataPtr = (int*)payloadPtr.Data;
+                                ushort id = (ushort)dataPtr[0];
+                                tile.Id = id;
+                                dict[pattern] = tile;
+                            }
+                        }
+                        ImGui.EndDragDropTarget();
+                    }
+                    ImGui.PopID();
                 }
                 ImGui.EndChild();
             }

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitionsPath.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitionsPath.cs
@@ -23,7 +23,7 @@ public partial class HeightMapGenerator
         {
             if (!File.Exists(path))
                 return;
-            var data = JsonSerializer.Deserialize<Dictionary<string, Tile[]>>(File.ReadAllText(path), new JsonSerializerOptions
+            var data = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, TransitionTile>>>(File.ReadAllText(path), new JsonSerializerOptions
             {
                 IncludeFields = true
             });

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.SaveTransitionsPath.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.SaveTransitionsPath.cs
@@ -24,16 +24,7 @@ public partial class HeightMapGenerator
             WriteIndented = true,
             IncludeFields = true
         };
-        // Serialize a simple representation to avoid accidentally picking up
-        // data from the tile group structure. Each transition entry is
-        // converted to a lightweight array containing only the terrain type
-        // and tile id information used by the generator.
-        var data = transitionTiles.ToDictionary(
-            kv => kv.Key,
-            kv => kv.Value
-                .Select(t => new { Type = t.Type, Id = t.Id })
-                .ToArray());
-        File.WriteAllText(path, JsonSerializer.Serialize(data, options));
+        File.WriteAllText(path, JsonSerializer.Serialize(transitionTiles, options));
         transitionsPath = path;
     }
 }

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.TransitionConverter.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.TransitionConverter.cs
@@ -27,22 +27,28 @@ public partial class HeightMapGenerator
         }
     }
 
+    private class TransitionTile
+    {
+        public int Id;
+        public int MinZ;
+        public int MaxZ;
+    }
+
     private class TransitionConverter
     {
-        private static readonly Dictionary<(int dx, int dy), int> IndexMap = new()
+        private static readonly (int dx, int dy)[] NeighborOffsets = new (int, int)[]
         {
-            {(-1, -1), 0}, // NW
-            {(0, -1), 1},  // N
-            {(1, -1), 2},  // NE
-            {(-1, 0), 3},  // W
-            {(0, 0), 4},   // Center
-            {(1, 0), 5},   // E
-            {(-1, 1), 6},  // SW
-            {(0, 1), 7},   // S
-            {(1, 1), 8}    // SE
+            (-1, -1), // NW
+            (0, -1),  // N
+            (1, -1),  // NE
+            (1, 0),   // E
+            (1, 1),   // SE
+            (0, 1),   // S
+            (-1, 1),  // SW
+            (-1, 0)   // W
         };
 
-        public void ApplyTransitions(Tile[,] map, Dictionary<string, Tile[]> transitionTiles)
+        public void ApplyTransitions(Tile[,] map, Dictionary<string, Dictionary<string, TransitionTile>> transitionTiles)
         {
             int width = map.GetLength(0);
             int height = map.GetLength(1);
@@ -55,18 +61,13 @@ public partial class HeightMapGenerator
                     var center = copy[x, y];
                     var counts = new Dictionary<TerrainType, int>();
 
-                    for (int dy = -1; dy <= 1; dy++)
+                    foreach (var (dx, dy) in NeighborOffsets)
                     {
-                        for (int dx = -1; dx <= 1; dx++)
-                        {
-                            if (dx == 0 && dy == 0)
-                                continue;
-                            var t = copy[x + dx, y + dy];
-                            if (t.Type == center.Type)
-                                continue;
-                            counts.TryGetValue(t.Type, out int c);
-                            counts[t.Type] = c + 1;
-                        }
+                        var t = copy[x + dx, y + dy];
+                        if (t.Type == center.Type)
+                            continue;
+                        counts.TryGetValue(t.Type, out int c);
+                        counts[t.Type] = c + 1;
                     }
 
                     if (counts.Count == 0)
@@ -86,46 +87,19 @@ public partial class HeightMapGenerator
                     if (max == 0)
                         continue;
 
-                    int bestIndex = 4;
-                    int bestCount = 0;
-                    foreach (var kv in IndexMap)
+                    Span<char> patternChars = stackalloc char[8];
+                    int i = 0;
+                    foreach (var (dx, dy) in NeighborOffsets)
                     {
-                        var (dx, dy) = kv.Key;
-                        if (dx == 0 && dy == 0)
-                            continue;
-                        var t = copy[x + dx, y + dy];
-                        if (t.Type == bType)
-                        {
-                            int idx = kv.Value;
-                            int count = 0;
-                            for (int ndy = -1; ndy <= 1; ndy++)
-                            {
-                                for (int ndx = -1; ndx <= 1; ndx++)
-                                {
-                                    if (ndx == 0 && ndy == 0)
-                                        continue;
-                                    int nx = x + dx + ndx;
-                                    int ny = y + dy + ndy;
-                                    if (nx < 0 || nx >= width || ny < 0 || ny >= height)
-                                        continue;
-                                    if (copy[nx, ny].Type == bType)
-                                        count++;
-                                }
-                            }
-                            if (count > bestCount)
-                            {
-                                bestCount = count;
-                                bestIndex = idx;
-                            }
-                        }
+                        patternChars[i++] = copy[x + dx, y + dy].Type == center.Type ? 'A' : 'B';
                     }
+                    string pattern = new(patternChars);
 
                     var key = $"{center.Type.ToString().ToLower()}-{bType.ToString().ToLower()}";
-                    if (transitionTiles.TryGetValue(key, out var tiles) && tiles.Length == 9)
+                    if (transitionTiles.TryGetValue(key, out var dict) && dict.TryGetValue(pattern, out var tileInfo))
                     {
-                        var tile = tiles[bestIndex];
-                        if (tile.Id != 0)
-                            map[x, y] = tile;
+                        if (tileInfo.Id != 0)
+                            map[x, y] = new Tile(center.Type, (ushort)tileInfo.Id);
                     }
                 }
             }

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
@@ -64,17 +64,17 @@ public partial class HeightMapGenerator : Window
     private readonly Perlin noise = new(Environment.TickCount);
 
     private readonly Dictionary<string, Group> tileGroups = new();
-    private readonly Dictionary<string, Tile[]> transitionTiles = new()
+    private readonly Dictionary<string, Dictionary<string, TransitionTile>> transitionTiles = new()
     {
-        ["water-sand"] = new Tile[9],
-        ["sand-water"] = new Tile[9],
-        ["sand-grass"] = new Tile[9],
-        ["grass-sand"] = new Tile[9],
-        ["grass-jungle"] = new Tile[9],
-        ["jungle-grass"] = new Tile[9],
-        ["jungle-rock"] = new Tile[9],
-        ["rock-jungle"] = new Tile[9],
-        ["rock-snow"] = new Tile[9]
+        ["water-sand"] = new(),
+        ["sand-water"] = new(),
+        ["sand-grass"] = new(),
+        ["grass-sand"] = new(),
+        ["grass-jungle"] = new(),
+        ["jungle-grass"] = new(),
+        ["jungle-rock"] = new(),
+        ["rock-jungle"] = new(),
+        ["rock-snow"] = new()
     };
     private string selectedGroup = string.Empty;
     private string selectedTransition = string.Empty;


### PR DESCRIPTION
## Summary
- add `TransitionTile` model for pattern entries
- store transition rules as pattern dictionaries
- refactor converter to use 8‑neighbour pattern strings
- adapt load/save logic for new JSON format
- update transition editor UI

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e27fc634832faf8f17487646226e