### PR TITLE
Fix missing using causing build error

### DIFF
--- a/CentrED/UI/Windows/TransitionTilesWindow.cs
+++ b/CentrED/UI/Windows/TransitionTilesWindow.cs
@@ -6,6 +6,7 @@ using System.Numerics;
 using ImGuiNET;
 using ClassicUO.Assets;
 using Microsoft.Xna.Framework.Graphics;
+using CentrED.IO.Models;
 using static CentrED.Application;
 
 namespace CentrED.UI.Windows;


### PR DESCRIPTION
## Summary
- include `CentrED.IO.Models` in `TransitionTilesWindow`

## Testing
- `dotnet build CentrEDSharp.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849ec078d9c832fa056c727e5acb9a1