### PR TITLE
Handle transition patterns by terrain type

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitionTiles.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitionTiles.cs
@@ -231,10 +231,11 @@ public partial class HeightMapGenerator
     {
         Span<char> pattern = stackalloc char[8];
         ushort center = entry.Tiles[4];
+        var centerType = GetTerrainType(center);
         for (int i = 0; i < 8; i++)
         {
             ushort val = entry.Tiles[PatternMap[i]];
-            pattern[i] = val == center ? 'A' : 'B';
+            pattern[i] = GetTerrainType(val) == centerType ? 'A' : 'B';
         }
         return new string(pattern);
     }

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.GetTerrainTypeByTile.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.GetTerrainTypeByTile.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Linq;
+
+namespace CentrED.UI.Windows;
+
+public partial class HeightMapGenerator
+{
+    private TerrainType GetTerrainType(ushort tileId)
+    {
+        foreach (var kv in tileGroups)
+        {
+            if (kv.Value.Ids.Contains(tileId) &&
+                Enum.TryParse<TerrainType>(kv.Key, true, out var type))
+            {
+                return type;
+            }
+        }
+        return TerrainType.Water;
+    }
+}


### PR DESCRIPTION
## Summary
- compute transition pattern using terrain types instead of raw tile ids
- add helper that maps a tile id to the terrain type via current groups

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a37893754832fafe7418d93c81f2a