### PR TITLE
Improve DragonMod export

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.ExportDragonMod.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.ExportDragonMod.cs
@@ -10,7 +10,15 @@ public partial class HeightMapGenerator
     private void ExportDragonMod(string path)
     {
         var export = ConvertTransitions();
-        var options = new JsonSerializerOptions { WriteIndented = true, IncludeFields = true };
+        dragonModEntries.Clear();
+        foreach (var kv in export)
+            dragonModEntries[kv.Key] = kv.Value;
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            IncludeFields = true
+        };
         File.WriteAllText(path, JsonSerializer.Serialize(export, options));
         dragonModPath = path;
     }


### PR DESCRIPTION
## Summary
- update ExportDragonMod to populate the in-memory dragonModEntries dictionary when exporting

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a431d2e30832f8823239c84644bfe