### PR TITLE
Improve transition tile mapping

### DIFF
--- a/CentrED.Tests/CentrED.Tests.csproj
+++ b/CentrED.Tests/CentrED.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <ProjectReference Include="..\CentrED\CentrED.csproj" />
+  </ItemGroup>
+</Project>

--- a/CentrED.Tests/HeightMapGeneratorPatternTests.cs
+++ b/CentrED.Tests/HeightMapGeneratorPatternTests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+using CentrED.UI.Windows;
+
+namespace CentrED.Tests;
+
+public class HeightMapGeneratorPatternTests
+{
+    [Theory]
+    [InlineData("AAAAAAAA", 4)]
+    [InlineData("AAAAAAAB", 3)]
+    [InlineData("AAAABBBB", 6)]
+    public void PatternMapsToExpectedIndex(string pattern, int expected)
+    {
+        int idx = HeightMapGenerator.GetTileIndexForPattern(pattern);
+        Assert.Equal(expected, idx);
+    }
+}

--- a/CentrED/AssemblyInfo.cs
+++ b/CentrED/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyFileVersion("0.0.1.0")]
 [assembly: AssemblyVersion("0.0.1.0")]
@@ -9,4 +10,5 @@
 [assembly: AssemblyCompany("Nelderim")]
 [assembly: AssemblyProduct("Centred#")]
 
+[assembly: InternalsVisibleTo("CentrED.Tests")]
 [assembly: AssemblyInformationalVersion("0.0.1+Branch.gitversion.Sha.0ee65457e499fadc5fd917bf211b8e3ceacac803")]

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitionTiles.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitionTiles.cs
@@ -210,7 +210,8 @@ public partial class HeightMapGenerator
             foreach (var entry in kv.Value)
             {
                 var pattern = ComputePattern(entry);
-                dict[pattern] = new TransitionTile { Id = entry.Tiles[4], MinZ = entry.MinZ, MaxZ = entry.MaxZ };
+                int mappedIndex = GetTileIndexForPattern(pattern);
+                dict[pattern] = new TransitionTile { Id = entry.Tiles[mappedIndex], MinZ = entry.MinZ, MaxZ = entry.MaxZ };
             }
             export[kv.Key] = dict;
         }
@@ -238,6 +239,28 @@ public partial class HeightMapGenerator
             pattern[i] = GetTerrainType(val) == centerType ? 'A' : 'B';
         }
         return new string(pattern);
+    }
+
+    internal static int GetTileIndexForPattern(string pattern)
+    {
+        bool n = pattern[1] == 'B';
+        bool e = pattern[3] == 'B';
+        bool s = pattern[5] == 'B';
+        bool w = pattern[7] == 'B';
+        bool nw = pattern[0] == 'B';
+        bool ne = pattern[2] == 'B';
+        bool se = pattern[4] == 'B';
+        bool sw = pattern[6] == 'B';
+
+        if (n && w && nw) return 0;
+        if (n && e && ne) return 2;
+        if (s && w && sw) return 6;
+        if (s && e && se) return 8;
+        if (n) return 1;
+        if (e) return 5;
+        if (s) return 7;
+        if (w) return 3;
+        return 4;
     }
 
 }


### PR DESCRIPTION
## Summary
- map patterns to tile indices when exporting transitions
- expose transition pattern helper and mark internals visible to tests
- add xUnit test project for pattern mapping

## Testing
- `dotnet test CentrED.Tests/CentrED.Tests.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4be31bcc832fb8fcd4b3fee0c462