### PR TITLE
Improve transition tile terrain type mapping

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.ExportDragonMod.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.ExportDragonMod.cs
@@ -9,6 +9,7 @@ public partial class HeightMapGenerator
 
     private void ExportDragonMod(string path)
     {
+        LoadTransitions();
         var export = ConvertTransitions();
         dragonModEntries.Clear();
         foreach (var kv in export)

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.GetTerrainTypeByTile.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.GetTerrainTypeByTile.cs
@@ -7,12 +7,15 @@ public partial class HeightMapGenerator
 {
     private TerrainType GetTerrainType(ushort tileId)
     {
+        if (_tileTypeMap.TryGetValue(tileId, out var type))
+            return type;
+
         foreach (var kv in tileGroups)
         {
             if (kv.Value.Ids.Contains(tileId) &&
-                Enum.TryParse<TerrainType>(kv.Key, true, out var type))
+                Enum.TryParse<TerrainType>(kv.Key, true, out var parsed))
             {
-                return type;
+                return parsed;
             }
         }
         return TerrainType.Water;

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitionsPath.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitionsPath.cs
@@ -30,8 +30,28 @@ public partial class HeightMapGenerator
             if (data == null)
                 return;
             transitions.Clear();
+            _tileTypeMap.Clear();
             foreach (var kv in data)
+            {
                 transitions[kv.Key] = kv.Value;
+                var parts = kv.Key.Split('-', 2);
+                if (parts.Length != 2 ||
+                    !Enum.TryParse<TerrainType>(parts[0], true, out var main) ||
+                    !Enum.TryParse<TerrainType>(parts[1], true, out var other))
+                    continue;
+
+                foreach (var entry in kv.Value)
+                {
+                    for (int i = 0; i < entry.Tiles.Length; i++)
+                    {
+                        ushort id = entry.Tiles[i];
+                        if (id == 0)
+                            continue;
+                        var type = i == 4 ? main : other;
+                        _tileTypeMap[id] = type;
+                    }
+                }
+            }
             if (!transitions.ContainsKey(selectedTransition))
                 selectedTransition = transitions.Keys.FirstOrDefault() ?? string.Empty;
             selectedIndex = 0;

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.cs
@@ -66,6 +66,7 @@ public partial class HeightMapGenerator : Window
     private readonly Perlin noise = new(Environment.TickCount);
 
     private readonly Dictionary<string, Group> tileGroups = new();
+    private readonly Dictionary<ushort, TerrainType> _tileTypeMap = new();
     private class TransitionEntry
     {
         public ushort[] Tiles = new ushort[9];


### PR DESCRIPTION
## Summary
- introduce a tile-type map for transition tiles
- fill the map when loading transition definitions
- prefer the map when determining a tile's terrain type
- load transitions before exporting DragonMod definitions

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a52b13108832fb7446c552747d306