### PR TITLE
Fix DragonMod export conversion

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.ExportDragonMod.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.ExportDragonMod.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 
 namespace CentrED.UI.Windows;
@@ -11,8 +10,7 @@ public partial class HeightMapGenerator
     private void ExportDragonMod(string path)
     {
         LoadTransitions();
-        var export = transitionConverter.ConvertTransitions(
-            tileGroups.ToDictionary(kv => kv.Key, kv => kv.Value.Ids));
+        var export = ConvertTransitions();
 
         dragonModEntries.Clear();
         foreach (var kv in export)


### PR DESCRIPTION
## Summary
- fix Export DragonMod so it converts from transitions instead of groups

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a638e76ac832f9727108941bbccb0