### PR TITLE
Remove transition buttons

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.InternalDraw.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.InternalDraw.cs
@@ -90,21 +90,6 @@ public partial class HeightMapGenerator
         ImGui.Separator();
         ImGui.Text("Transition Tiles");
         DrawTransitionTiles();
-        if (ImGui.Button("Save Transitions"))
-        {
-            if (TinyFileDialogs.TrySaveFile("Save Transitions", transitionsPath, new[] { "*.json" }, "JSON Files", out var path))
-            {
-                SaveTransitions(path);
-            }
-        }
-        ImGui.SameLine();
-        if (ImGui.Button("Load Transitions"))
-        {
-            if (TinyFileDialogs.TryOpenFile("Load Transitions", Environment.CurrentDirectory, new[] { "*.json" }, "JSON Files", false, out var path))
-            {
-                LoadTransitions(path);
-            }
-        }
         ImGui.Separator();
 
         ImGui.BeginDisabled(heightData == null || generationTask != null && !generationTask.IsCompleted);


### PR DESCRIPTION
## Summary
- remove duplicate "Save Transitions" and "Load Transitions" buttons from HeightMapGenerator

## Testing
- `git show --stat`
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a649237c0832fabadef6a3e0fd68b