### PR TITLE
Fix transition tile validation

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitionTiles.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitionTiles.cs
@@ -221,9 +221,17 @@ public partial class HeightMapGenerator
 
             foreach (var entry in kv.Value)
             {
+                // Skip incomplete entries (center tile must be defined)
+                if (entry.Tiles[4] == 0)
+                    continue;
                 var pattern = ComputePattern(entry);
                 int mappedIndex = GetTileIndexForPattern(pattern);
-                dict[pattern] = new TransitionTile { Id = entry.Tiles[mappedIndex], MinZ = entry.MinZ, MaxZ = entry.MaxZ };
+                dict[pattern] = new TransitionTile
+                {
+                    Id = entry.Tiles[mappedIndex],
+                    MinZ = entry.MinZ,
+                    MaxZ = entry.MaxZ
+                };
             }
         }
 


### PR DESCRIPTION
## Summary
- skip incomplete transition entries so generation doesn't crash if not all transition tiles are filled

## Testing
- `dotnet build CentrEDSharp.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a744e73fc832fb5f562477fe8e950