### PR TITLE
Fix null transition tiles in heightmap generator

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitionTiles.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.DrawTransitionTiles.cs
@@ -221,6 +221,14 @@ public partial class HeightMapGenerator
 
             foreach (var entry in kv.Value)
             {
+                if (entry.Tiles == null || entry.Tiles.Length < 9)
+                {
+                    var tiles = new ushort[9];
+                    if (entry.Tiles != null)
+                        Array.Copy(entry.Tiles, tiles, Math.Min(entry.Tiles.Length, 9));
+                    entry.Tiles = tiles;
+                }
+
                 // Skip incomplete entries (center tile must be defined)
                 if (entry.Tiles[4] == 0)
                     continue;
@@ -251,6 +259,9 @@ public partial class HeightMapGenerator
     private string ComputePattern(TransitionEntry entry)
     {
         Span<char> pattern = stackalloc char[8];
+        if (entry.Tiles == null || entry.Tiles.Length < 9)
+            return "AAAAAAAA";
+
         ushort center = entry.Tiles[4];
         var centerType = GetTerrainType(center);
         for (int i = 0; i < 8; i++)

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitionsPath.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitionsPath.cs
@@ -42,6 +42,15 @@ public partial class HeightMapGenerator
 
                 foreach (var entry in kv.Value)
                 {
+                    if (entry.Tiles == null)
+                        entry.Tiles = new ushort[9];
+                    else if (entry.Tiles.Length < 9)
+                    {
+                        var tiles = new ushort[9];
+                        Array.Copy(entry.Tiles, tiles, entry.Tiles.Length);
+                        entry.Tiles = tiles;
+                    }
+
                     for (int i = 0; i < entry.Tiles.Length; i++)
                     {
                         ushort id = entry.Tiles[i];


### PR DESCRIPTION
## Summary
- handle null or short `Tiles` arrays when loading transition data
- validate transition entries before converting and generating patterns

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a761ff928832fbbebca9c52f69966