### PR TITLE
Improve feedback for HeightMapGenerator load errors

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.Generate.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.Generate.cs
@@ -33,37 +33,46 @@ public partial class HeightMapGenerator
         showProgressPopup = true;
         generationTask = Task.Run(() =>
         {
-            var groupsList = tileGroups.Values.Where(g => g.Ids.Count > 0).ToList();
-            if (groupsList.Count == 0)
-            {
-                _statusText = "No groups configured.";
-                _statusColor = UIManager.Red;
-                return;
-            }
-
-            var total = MapSizeX * MapSizeY;
-            if (total > MaxTiles)
-                return;
-            CEDClient.BulkMode = true;
             try
             {
-                GenerateFractalRegion(x1, y1, MapSizeX, MapSizeY, groupsList, total, token);
+                var groupsList = tileGroups.Values.Where(g => g.Ids.Count > 0).ToList();
+                if (groupsList.Count == 0)
+                {
+                    _statusText = "No groups configured.";
+                    _statusColor = UIManager.Red;
+                    return;
+                }
+
+                var total = MapSizeX * MapSizeY;
+                if (total > MaxTiles)
+                    return;
+                CEDClient.BulkMode = true;
+                try
+                {
+                    GenerateFractalRegion(x1, y1, MapSizeX, MapSizeY, groupsList, total, token);
+                }
+                finally
+                {
+                    CEDClient.BulkMode = false;
+                    CEDClient.Flush();
+                    // Ensure pending packets are sent immediately after bulk mode
+                    CEDClient.Update();
+                }
+                if (token.IsCancellationRequested)
+                {
+                    _statusText = "Generation cancelled.";
+                    _statusColor = UIManager.Red;
+                }
+                else
+                {
+                    generationProgress = 1f;
+                }
             }
-            finally
+            catch (Exception ex)
             {
-                CEDClient.BulkMode = false;
-                CEDClient.Flush();
-                // Ensure pending packets are sent immediately after bulk mode
-                CEDClient.Update();
-            }
-            if (token.IsCancellationRequested)
-            {
-                _statusText = "Generation cancelled.";
+                Console.WriteLine($"Generation error: {ex.Message}");
+                _statusText = $"Generation failed: {ex.Message}";
                 _statusColor = UIManager.Red;
-            }
-            else
-            {
-                generationProgress = 1f;
             }
         }, token);
     }

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadDragonModPath.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadDragonModPath.cs
@@ -12,21 +12,37 @@ public partial class HeightMapGenerator
         try
         {
             if (!File.Exists(path))
+            {
+                _statusText = $"DragonMod file not found: {Path.GetFileName(path)}";
+                _statusColor = UIManager.Red;
                 return;
+            }
+
             var data = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, TransitionTile>>>(File.ReadAllText(path), new JsonSerializerOptions
             {
                 IncludeFields = true
             });
+
             if (data == null)
+            {
+                _statusText = "Invalid DragonMod file.";
+                _statusColor = UIManager.Red;
                 return;
+            }
+
             dragonModEntries.Clear();
             foreach (var kv in data)
                 dragonModEntries[kv.Key] = kv.Value;
+
             dragonModPath = path;
+            _statusText = $"Loaded DragonMod from {Path.GetFileName(path)}";
+            _statusColor = UIManager.Green;
         }
         catch (Exception e)
         {
             Console.WriteLine($"Failed to load dragonmod transitions: {e.Message}");
+            _statusText = $"Failed to load DragonMod: {e.Message}";
+            _statusColor = UIManager.Red;
         }
     }
 }

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadGroupsPath.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadGroupsPath.cs
@@ -22,21 +22,37 @@ public partial class HeightMapGenerator
         try
         {
             if (!File.Exists(path))
+            {
+                _statusText = $"Groups file not found: {Path.GetFileName(path)}";
+                _statusColor = UIManager.Red;
                 return;
+            }
+
             var data = JsonSerializer.Deserialize<Dictionary<string, Group>>(File.ReadAllText(path), new JsonSerializerOptions
             {
                 IncludeFields = true
             });
+
             if (data == null)
+            {
+                _statusText = "Invalid groups file.";
+                _statusColor = UIManager.Red;
                 return;
+            }
+
             tileGroups.Clear();
             foreach (var kv in data)
                 tileGroups[kv.Key] = kv.Value;
+
             groupsPath = path;
+            _statusText = $"Loaded groups from {Path.GetFileName(path)}";
+            _statusColor = UIManager.Green;
         }
         catch (Exception e)
         {
             Console.WriteLine($"Failed to load groups: {e.Message}");
+            _statusText = $"Failed to load groups: {e.Message}";
+            _statusColor = UIManager.Red;
         }
     }
 }

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadHeightmap.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadHeightmap.cs
@@ -34,12 +34,16 @@ public partial class HeightMapGenerator
 
             UpdateHeightData();
             heightMapPath = path;
+            _statusText = $"Loaded heightmap {Path.GetFileName(path)}";
+            _statusColor = UIManager.Green;
         }
         catch (Exception e)
         {
             Console.WriteLine($"Failed to load heightmap: {e.Message}");
             heightData = null;
             heightMapPath = string.Empty;
+            _statusText = $"Failed to load heightmap: {e.Message}";
+            _statusColor = UIManager.Red;
         }
     }
 }

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitionsPath.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.LoadTransitionsPath.cs
@@ -22,13 +22,23 @@ public partial class HeightMapGenerator
         try
         {
             if (!File.Exists(path))
+            {
+                _statusText = $"Transitions file not found: {Path.GetFileName(path)}";
+                _statusColor = UIManager.Red;
                 return;
+            }
+
             var data = JsonSerializer.Deserialize<Dictionary<string, List<TransitionEntry>>>(File.ReadAllText(path), new JsonSerializerOptions
             {
                 IncludeFields = true
             });
+
             if (data == null)
+            {
+                _statusText = "Invalid transitions file.";
+                _statusColor = UIManager.Red;
                 return;
+            }
             transitions.Clear();
             _tileTypeMap.Clear();
             foreach (var kv in data)
@@ -65,10 +75,14 @@ public partial class HeightMapGenerator
                 selectedTransition = transitions.Keys.FirstOrDefault() ?? string.Empty;
             selectedIndex = 0;
             transitionsPath = path;
+            _statusText = $"Loaded transitions from {Path.GetFileName(path)}";
+            _statusColor = UIManager.Green;
         }
         catch (Exception e)
         {
             Console.WriteLine($"Failed to load transitions: {e.Message}");
+            _statusText = $"Failed to load transitions: {e.Message}";
+            _statusColor = UIManager.Red;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add user-visible status updates when loading heightmap generator files
- show errors if JSON files are missing or invalid
- capture exceptions during generation and display message

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7b9b8880832f88686d109ab46fc7