### PR TITLE
Improve DragonMod export error handling

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.ExportDragonMod.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.ExportDragonMod.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text.Json;
 
@@ -9,19 +10,30 @@ public partial class HeightMapGenerator
 
     private void ExportDragonMod(string path)
     {
-        LoadTransitions();
-        var export = ConvertTransitions();
-
-        dragonModEntries.Clear();
-        foreach (var kv in export)
-            dragonModEntries[kv.Key] = kv.Value;
-
-        var options = new JsonSerializerOptions
+        try
         {
-            WriteIndented = true,
-            IncludeFields = true
-        };
-        File.WriteAllText(path, JsonSerializer.Serialize(export, options));
-        dragonModPath = path;
+            LoadTransitions();
+            var export = ConvertTransitions();
+
+            dragonModEntries.Clear();
+            foreach (var kv in export)
+                dragonModEntries[kv.Key] = kv.Value;
+
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                IncludeFields = true
+            };
+            File.WriteAllText(path, JsonSerializer.Serialize(export, options));
+            dragonModPath = path;
+            _statusText = $"Exported DragonMod to {Path.GetFileName(path)}";
+            _statusColor = UIManager.Green;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"Failed to export DragonMod: {e.Message}");
+            _statusText = $"Failed to export DragonMod: {e.Message}";
+            _statusColor = UIManager.Red;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle exceptions when exporting DragonMod files

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7d716988832f8d8aa5d514dff8a1