### PR TITLE
Add global crash logger

### DIFF
--- a/CentrED/Application.cs
+++ b/CentrED/Application.cs
@@ -2,6 +2,7 @@
 using CentrED.Client;
 using CentrED.Server;
 using CentrED.Utils;
+using CentrED.Utility;
 
 namespace CentrED;
 
@@ -18,7 +19,9 @@ public class Application
     public static void Main(string[] args)
     {
         CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
-        
+
+        CrashLogger.Init();
+
         Console.WriteLine($"Root Dir: {WorkDir}");
 
         Config.Initialize();

--- a/Server/Application.cs
+++ b/Server/Application.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using CentrED.Server.Config;
+using CentrED.Utility;
 
 namespace CentrED.Server;
 
@@ -14,6 +15,7 @@ public class Application
         Console.WriteLine(title);
         Console.WriteLine("Copyright 2024 Kaczy" );
         Console.WriteLine("Credits to Andreas Schneider, StaticZ");
+        CrashLogger.Init();
         try
         {
             var config = ConfigRoot.Init(args);

--- a/Shared/Utility/CrashLogger.cs
+++ b/Shared/Utility/CrashLogger.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace CentrED.Utility;
+
+public static class CrashLogger
+{
+    private const string CrashLogFile = "Crash.log";
+
+    public static void Init()
+    {
+        AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+        TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+    }
+
+    private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+    {
+        if (e.ExceptionObject is Exception ex)
+            LogException(ex);
+    }
+
+    private static void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+    {
+        LogException(e.Exception);
+    }
+
+    private static void LogException(Exception e)
+    {
+        try
+        {
+            File.AppendAllText(CrashLogFile, $"[{DateTime.Now}] {e}{Environment.NewLine}");
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- capture unhandled exceptions to `Crash.log`
- start crash logger early in both server and client apps

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7f339aa0832fb09e6c0e11886b70