### PR TITLE
Add note about fetching submodules

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,9 @@ Clone o repositório com:
 ```bash
 git clone --recursive https://github.com/kaczy93/centredsharp.git
 ```
+Caso já tenha clonado o repositório sem a opção `--recursive`,
+execute `git submodule update --init --recursive` para baixar
+os submódulos necessários.
 
 Em seguida, execute:
 


### PR DESCRIPTION
## Summary
- document how to fetch missing submodules if the repo wasn't cloned recursively

## Testing
- `dotnet test CentrED.Tests/CentrED.Tests.csproj -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a8251f88c832fb2a83b52ca404618