### PR TITLE
Fix popup handling for failed generation

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.Generate.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.Generate.cs
@@ -71,8 +71,14 @@ public partial class HeightMapGenerator
             catch (Exception ex)
             {
                 Console.WriteLine($"Generation error: {ex.Message}");
+                CrashLogger.Log(ex);
                 _statusText = $"Generation failed: {ex.Message}";
                 _statusColor = UIManager.Red;
+            }
+            finally
+            {
+                showProgressPopup = false;
+                openProgressPopup = false;
             }
         }, token);
     }

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.InternalDraw.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.InternalDraw.cs
@@ -101,14 +101,15 @@ public partial class HeightMapGenerator
         ImGui.TextColored(UIManager.Red, "This operation cannot be undone!");
         if (generationTask != null)
         {
-            if (generationTask.IsCompleted)
-            {
-                generationTask = null;
-                generationProgress = 0f;
-                cancellationSource?.Dispose();
-                cancellationSource = null;
-                showProgressPopup = false;
-            }
+                if (generationTask.IsCompleted)
+                {
+                    generationTask = null;
+                    generationProgress = 0f;
+                    cancellationSource?.Dispose();
+                    cancellationSource = null;
+                    showProgressPopup = false;
+                    openProgressPopup = false;
+                }
         }
 
         if (openProgressPopup)

--- a/Shared/Utility/CrashLogger.cs
+++ b/Shared/Utility/CrashLogger.cs
@@ -36,4 +36,9 @@ public static class CrashLogger
             // ignored
         }
     }
+
+    public static void Log(Exception e)
+    {
+        LogException(e);
+    }
 }


### PR DESCRIPTION
## Summary
- log generation task failures via `CrashLogger`
- close progress popup when the generation task completes or fails
- expose `CrashLogger.Log` for external logging

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a83494ce8832fb26c27d5319e6f03