### PR TITLE
Add height map validation

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.BuildTileMap.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.BuildTileMap.cs
@@ -19,6 +19,13 @@ public partial class HeightMapGenerator
 
     private void EnsureTileMap(bool applyTransitions = false)
     {
+        if (tileGroups.Count == 0 || heightData == null)
+        {
+            _statusText = "Height data or tile groups not loaded.";
+            _statusColor = UIManager.Red;
+            return;
+        }
+
         if (tileMap != null && tileMap.Length < MapSizeX * MapSizeY)
             tileMap = new Tile[MapSizeX, MapSizeY];
 

--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.Generate.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.Generate.cs
@@ -28,6 +28,13 @@ public partial class HeightMapGenerator
         if (generationTask != null && !generationTask.IsCompleted)
             return;
 
+        if (tileGroups.Count == 0 || heightData == null)
+        {
+            _statusText = "Height data or tile groups not loaded.";
+            _statusColor = UIManager.Red;
+            return;
+        }
+
         _statusText = string.Empty;
         cancellationSource = new CancellationTokenSource();
         var token = cancellationSource.Token;


### PR DESCRIPTION
## Summary
- validate loaded tile groups and height data before generating
- add the same validation to `EnsureTileMap`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685256deefa4832fa2942815fcd6c15f