### PR TITLE
Fix tile map initialization order

### DIFF
--- a/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.BuildTileMap.cs
+++ b/CentrED/UI/Windows/HeightMapGenerator/HeightMapGenerator.BuildTileMap.cs
@@ -22,7 +22,6 @@ public partial class HeightMapGenerator
         if (heightData == null)
             UpdateHeightData();
         InitializeTileIdToType();
-        BuildTileMap(applyTransitions);
         if (tileGroups.Count == 0 || heightData == null)
         {
             _statusText = "Height data or tile groups not loaded.";
@@ -41,6 +40,8 @@ public partial class HeightMapGenerator
             _statusColor = UIManager.Green;
 
         }
+
+        BuildTileMap(applyTransitions);
 
     }
     private void BuildTileMap(bool applyTransitions = false)


### PR DESCRIPTION
## Summary
- ensure tileMap is allocated before invoking BuildTileMap

## Testing
- `dotnet test --no-build` *(fails: project files for FNA/ImGui.NET not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525a0db400832f936a807429d352e2